### PR TITLE
Test for empty string as well

### DIFF
--- a/src/Emulator/Extensions/Utilities/GDB/Commands/MonitorCommand.cs
+++ b/src/Emulator/Extensions/Utilities/GDB/Commands/MonitorCommand.cs
@@ -33,7 +33,7 @@ namespace Antmicro.Renode.Utilities.GDB.Commands
                 result = eater.GetContents();
             }
 
-            return (result == null) ? PacketData.Success : new PacketData(string.Join(string.Empty, Encoding.UTF8.GetBytes(result).Select(x => x.ToString("X2"))));
+            return (string.IsNullOrEmpty(result)) ? PacketData.Success : new PacketData(string.Join(string.Empty, Encoding.UTF8.GetBytes(result).Select(x => x.ToString("X2"))));
         }
 
         private readonly OpenOcdOverlay openOcdOverlay;


### PR DESCRIPTION
The MonitorCommand class interprets the qRcmd packets which are generated from gdb by issuing "monitor xyz" commands. The response has to adhere to this schema:

```
qRcmd,command
command(hex encoded) is passed to the local interpreter for execution. Invalid commands should be reported using the output string. Before the final result packet, the target may also respond with a number of intermediate ‘Ooutput’ console output packets. Implementors should note that providing access to a stubs’s interpreter may have security implications.

Reply:
‘OK’ A command response with no output.
‘OUTPUT’ A command response with the hex encoded output string OUT-PUT.
‘ENN’ Indicate a badly formed request.
‘’ An empty reply indicates that qRcmd is not recognized.
```

But all commands who do not return anything but are working and are valid will still be recognized as unsupported commands. More details in the issue here: https://github.com/renode/renode/issues/26

My understanding might be wrong and I'm just doing it quickly, but this is what I understand. The MonitorCommand.Run will execute the command and check for errors and respond with an error code. Then it will check for null **result** to decide if OK or the reply message should be sent. Problem is that the **result** will never be null because:

- The **result** is populated with CommandInteractionEater.GetContent() https://github.com/renode/renode-infrastructure/blob/master/src/Emulator/Extensions/UserInterface/CommandInteractionEater.cs#L98 which is executing data.ToString(); which will either return a valid string (empty string is a valid string) or have a null exception, because null will not have ToString member.

- But the null exception will not happen as the data is initialized straight away here: https://github.com/renode/renode-infrastructure/blob/master/src/Emulator/Extensions/UserInterface/CommandInteractionEater.cs#L113

Therefore when there is no response there won't be any null and checking for the null might be redundant. The check should be checking for an empty string to respond with "OK", this way the check will be missed and it will continue to parse the **result** as a valid response, which will end up as empty, which will be understood by gdb as an unsupported command.

I propose to change the null check to a null check with empty string check. The null checking might be redundant but it feels safer.
