### PR TITLE
Allowing OUTPUT GPIOs to be set

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/PSE_GPIO.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/PSE_GPIO.cs
@@ -63,7 +63,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                             var bits = BitHelper.GetBits(val);
                             for(var i = 0; i < bits.Length; i++)
                             {
-                                if((irqManager.PinDirection[i] & GPIOInterruptManager.Direction.Input) == 0)
+                                if((irqManager.PinDirection[i] & GPIOInterruptManager.Direction.Output) != 0)
                                 {
                                     Connections[i].Set(bits[i]);
                                 }

--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/PSE_GPIO.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/PSE_GPIO.cs
@@ -63,7 +63,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                             var bits = BitHelper.GetBits(val);
                             for(var i = 0; i < bits.Length; i++)
                             {
-                                if((irqManager.PinDirection[i] & GPIOInterruptManager.Direction.Input) != 0)
+                                if((irqManager.PinDirection[i] & GPIOInterruptManager.Direction.Input) == 0)
                                 {
                                     Connections[i].Set(bits[i]);
                                 }


### PR DESCRIPTION
If my understanding is correct the desired logic is to set the output state only on OUTPUT GPIOs, while this condition will exact opposite, allow to set output state only on INPUT GPIOs.