### PR TITLE
Read offset behavior is consistent with Write

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/UART/NS16550.cs
+++ b/src/Emulator/Peripherals/Peripherals/UART/NS16550.cs
@@ -210,6 +210,7 @@ namespace Antmicro.Renode.Peripherals.UART
             }
             lock(UARTLock)
             {
+                offset &= 7;
                 byte value = 0x0;
                 if((lineControl & LineControl.DivisorLatchAccess) != 0)
                 {


### PR DESCRIPTION
Write is considering only the first 3 bits of the address. In an edge case it wraps around when given higher offsets. The same behavior should be observed with Read, making both consistent with each other.