### PR TITLE
Enabled back the autoUpdate in the 64bit PSE_Timer mode

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Timers/PSE_Timer.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/PSE_Timer.cs
@@ -29,7 +29,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             {
                 new LimitTimer(machine.ClockSource, frequency, this, "0", uint.MaxValue, autoUpdate: true, eventEnabled: true),
                 new LimitTimer(machine.ClockSource, frequency, this, "1", uint.MaxValue, autoUpdate: true, eventEnabled: true),
-                new LimitTimer(machine.ClockSource, frequency, this, "2", eventEnabled: true)
+                new LimitTimer(machine.ClockSource, frequency, this, "2", autoUpdate: true, eventEnabled: true)
             };
 
             for (var i = 0; i < NumberOfInternalTimers; i++)


### PR DESCRIPTION
When the autoUpdate was left out then it went to default (false) value. Previously the autoUpdate was set to true the 64-bit timer as well, but this change removed it:

https://github.com/renode/renode-infrastructure/commit/52d5aec6c787c348a5e03825e144bc58dba14b79