### PR TITLE
emulator: cores: parameterize ArPath

### DIFF
--- a/src/Emulator/Cores/linux-properties.csproj
+++ b/src/Emulator/Cores/linux-properties.csproj
@@ -3,6 +3,7 @@
 <PropertyGroup>
   <CompilerPath>/usr/bin/gcc</CompilerPath>
   <LinkerPath>/usr/bin/gcc</LinkerPath>
+  <ArPath>/usr/bin/ar</ArPath>
   <CurrentPlatform>Linux</CurrentPlatform>
   <DefineConstants>$(DefineConstants);PLATFORM_LINUX</DefineConstants>
 </PropertyGroup>

--- a/src/Emulator/Cores/osx-properties.csproj
+++ b/src/Emulator/Cores/osx-properties.csproj
@@ -3,6 +3,7 @@
 <PropertyGroup>
   <CompilerPath>/usr/bin/clang</CompilerPath>
   <LinkerPath>/usr/bin/clang</LinkerPath>
+  <ArPath>/usr/bin/ar</ArPath>
   <CurrentPlatform>OSX</CurrentPlatform>
   <DefineConstants>$(DefineConstants);PLATFORM_OSX</DefineConstants>
 </PropertyGroup>

--- a/src/Emulator/Cores/tcg.cproj
+++ b/src/Emulator/Cores/tcg.cproj
@@ -6,7 +6,9 @@
     <Architecture Condition=" $(Architecture) == '' ">i386</Architecture>
     <TcgDirectory>tlib/tcg</TcgDirectory>
     <OutputDirectory>$(TcgDirectory)/bin/$(Configuration)</OutputDirectory>
+    <PropertiesLocation>..\..\..\..\..\output\properties.csproj</PropertiesLocation>
   </PropertyGroup>
+  <Import Project="$(PropertiesLocation)" />
 
   <Target Name="_VerifyProperties">
     <Error Text="Target word size not provided" Condition=" $(TargetWordSize) == '' " />
@@ -50,7 +52,7 @@
       <ObjectFilesString>@(ObjectFiles->'%(Identity)', ' ')</ObjectFilesString>
     </PropertyGroup>
     <MakeDir Directories="$(OutputDirectory)"/>
-    <Exec Command="ar rcs $(TcgOutput) $(ObjectFilesString)" Condition=" !Exists('$(TcgOutput)') Or '$(ObjectFilesString)' != '' "/>
+    <Exec Command="$(ArPath) rcs $(TcgOutput) $(ObjectFilesString)" Condition=" !Exists('$(TcgOutput)') Or '$(ObjectFilesString)' != '' "/>
   </Target>
 
   <Target Name="Clean">

--- a/src/Emulator/Cores/windows-properties.csproj
+++ b/src/Emulator/Cores/windows-properties.csproj
@@ -3,6 +3,7 @@
 <PropertyGroup>
   <CompilerPath>gcc</CompilerPath>
   <LinkerPath>gcc</LinkerPath>
+  <ArPath>ar</ArPath>
   <CurrentPlatform>Windows</CurrentPlatform>
   <DefineConstants>$(DefineConstants);PLATFORM_WINDOWS</DefineConstants>
 </PropertyGroup>


### PR DESCRIPTION
The linker and the compiler paths are both parameterized as LinkerPath
and CompilerPath already.  This allows for them to be placed in a
nonstandard location, or even outside of the path entirely.

Note that with this change, users must re-sync the properties file, or
manually add ArPath.

This allows me to build on Windows, where gcc is not in my path.