### PR TITLE
Cpu.TranslateAddress fixes

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/CPU/TranslationCPU.cs
+++ b/src/Emulator/Peripherals/Peripherals/CPU/TranslationCPU.cs
@@ -1398,7 +1398,12 @@ namespace Antmicro.Renode.Peripherals.CPU
 
         public ulong TranslateAddress(ulong logicalAddress)
         {
-            return TlibTranslateToPhysicalAddress(logicalAddress);
+            return TlibTranslateCodeAddressToPhysicalAddress(logicalAddress);
+        }
+
+        public ulong TranslateDataAddress(ulong logicalAddress)
+        {
+            return TlibTranslateDataAddressToPhysicalAddress(logicalAddress);
         }
 
         [PostDeserialization]
@@ -1518,7 +1523,10 @@ namespace Antmicro.Renode.Peripherals.CPU
         private ActionIntPtrIntPtr TlibInvalidateTranslationBlocks;
 
         [Import]
-        protected FuncUInt64UInt64 TlibTranslateToPhysicalAddress;
+        protected FuncUInt64UInt64 TlibTranslateCodeAddressToPhysicalAddress;
+
+        [Import]
+        protected FuncUInt64UInt64 TlibTranslateDataAddressToPhysicalAddress;
 
         [Import]
         private ActionIntPtrInt32 RenodeSetHostBlocks;


### PR DESCRIPTION
CPU.TranslateAddress would sometimes return -1 when the address is valid.  Additionally, it couldn't properly handle data addresses.  The underlying tlib support was fixed, and an additional API added to support translation of data addresses vs code addresses.

This pull request has to be taken in conjunction with a similarly named pull request on antmicro/tlib.