### PR TITLE
Cortex-M: Implement NMIPENDSET bit in ICSR to trigger an NMI

### DIFF
--- a/src/Emulator/Cores/Arm-M/NVIC.cs
+++ b/src/Emulator/Cores/Arm-M/NVIC.cs
@@ -174,6 +174,9 @@ namespace Antmicro.Renode.Peripherals.IRQControllers
                 {
                     SetPendingIRQ(14);
                 }
+                if ((value & (1u << 31)) !=0) {
+                    SetPendingIRQ(2);
+                }
                 break;
             case Registers.VectorTableOffset:
                 cpu.VectorTableOffset = value & 0xFFFFFF80;


### PR DESCRIPTION
Register definition: https://developer.arm.com/documentation/dui0552/a/cortex-m3-peripherals/system-control-block/interrupt-control-and-state-register

The NMIPENDSET bit is used to trigger an NMI via software.