### PR TITLE
50 gdb support specific features

### DIFF
--- a/src/Emulator/Cores/Arm-M/CortexM.cs
+++ b/src/Emulator/Cores/Arm-M/CortexM.cs
@@ -54,7 +54,35 @@ namespace Antmicro.Renode.Peripherals.CPU
 
         public override string Architecture { get { return "arm-m"; } }
 
-        public override List<IGBDFeature> GDBFeatures { get { return new List<IGBDFeature>(); } }
+        public override List<GBDFeatureDescriptor> GDBFeatures
+        {
+            get
+            {
+                var features = new List<GBDFeatureDescriptor>();
+
+                var mProfileFeature = new GBDFeatureDescriptor("org.gnu.gdb.arm.m-profile");
+                for(var index = 0u; index <= 12; index++)
+                {
+                    mProfileFeature.Registers.Add(new GBDRegisterDescriptor(index, 32, $"r{index}", "uint32", "general"));
+                }
+                mProfileFeature.Registers.Add(new GBDRegisterDescriptor(13, 32, "sp", "data_ptr", "general"));
+                mProfileFeature.Registers.Add(new GBDRegisterDescriptor(14, 32, "lr", "uint32", "general"));
+                mProfileFeature.Registers.Add(new GBDRegisterDescriptor(15, 32, "pc", "code_ptr", "general"));
+                mProfileFeature.Registers.Add(new GBDRegisterDescriptor(25, 32, "xpsr", "uint32", "general"));
+                features.Add(mProfileFeature);
+
+                var mSystemFeature = new GBDFeatureDescriptor("org.gnu.gdb.arm.m-system");
+                mSystemFeature.Registers.Add(new GBDRegisterDescriptor(26, 32, "msp", "uint32", "general"));
+                mSystemFeature.Registers.Add(new GBDRegisterDescriptor(27, 32, "psp", "uint32", "general"));
+                mSystemFeature.Registers.Add(new GBDRegisterDescriptor(28, 32, "primask", "uint32", "general"));
+                mSystemFeature.Registers.Add(new GBDRegisterDescriptor(29, 32, "basepri", "uint32", "general"));
+                mSystemFeature.Registers.Add(new GBDRegisterDescriptor(30, 32, "faultmask", "uint32", "general"));
+                mSystemFeature.Registers.Add(new GBDRegisterDescriptor(31, 32, "control", "uint32", "general"));
+                features.Add(mSystemFeature);
+
+                return features;
+            }
+        }
 
         public uint VectorTableOffset
         {

--- a/src/Emulator/Cores/Arm-M/CortexM.cs
+++ b/src/Emulator/Cores/Arm-M/CortexM.cs
@@ -6,6 +6,7 @@
 // Full license text is available in 'licenses/MIT.txt'.
 //
 using System;
+using System.Collections.Generic;
 using Antmicro.Renode.Core;
 using Antmicro.Renode.Peripherals.Bus;
 using Antmicro.Renode.Peripherals.IRQControllers;
@@ -52,6 +53,8 @@ namespace Antmicro.Renode.Peripherals.CPU
         }
 
         public override string Architecture { get { return "arm-m"; } }
+
+        public override List<IGBDFeature> GDBFeatures { get { return new List<IGBDFeature>(); } }
 
         public uint VectorTableOffset
         {

--- a/src/Emulator/Cores/Arm/Arm.cs
+++ b/src/Emulator/Cores/Arm/Arm.cs
@@ -50,6 +50,8 @@ namespace Antmicro.Renode.Peripherals.CPU
         //gdb does not contain arm-m and armv7 as independent architecteures so we need to pass "arm" in every case.
         public override string GDBArchitecture { get { return "arm"; } }
 
+        public override List<GBDFeatureDescriptor> GDBFeatures { get { return new List<GBDFeatureDescriptor>(); } }
+
         public uint ID
         {
             get

--- a/src/Emulator/Cores/PowerPC/PowerPc.cs
+++ b/src/Emulator/Cores/PowerPC/PowerPc.cs
@@ -74,6 +74,8 @@ namespace Antmicro.Renode.Peripherals.CPU
 
         public override string GDBArchitecture { get { return "powerpc:common"; } }
 
+        public override List<GBDFeatureDescriptor> GDBFeatures { get { return new List<GBDFeatureDescriptor>(); } }
+
         protected override Interrupt DecodeInterrupt(int number)
         {
             if(number == 0)

--- a/src/Emulator/Cores/PowerPC/PowerPc64.cs
+++ b/src/Emulator/Cores/PowerPC/PowerPc64.cs
@@ -74,6 +74,8 @@ namespace Antmicro.Renode.Peripherals.CPU
 
         public override string GDBArchitecture { get { return "powerpc:common64"; } }
 
+        public override List<GBDFeatureDescriptor> GDBFeatures { get { return new List<GBDFeatureDescriptor>(); } }
+
         protected override Interrupt DecodeInterrupt(int number)
         {
             if(number == 0)

--- a/src/Emulator/Cores/RiscV/RiscV32.cs
+++ b/src/Emulator/Cores/RiscV/RiscV32.cs
@@ -4,6 +4,7 @@
 // This file is licensed under the MIT License.
 // Full license text is available in 'licenses/MIT.txt'.
 //
+using System.Collections.Generic;
 using Antmicro.Renode.Core;
 using Antmicro.Renode.Peripherals.Timers;
 using Endianess = ELFSharp.ELF.Endianess;
@@ -20,6 +21,8 @@ namespace Antmicro.Renode.Peripherals.CPU
         public override string Architecture { get { return "riscv"; } }
 
         public override string GDBArchitecture { get { return "riscv:rv32"; } }
+
+        public override List<GBDFeatureDescriptor> GDBFeatures { get { return new List<GBDFeatureDescriptor>(); } }
 
         protected override byte MostSignificantBit => 31;
 

--- a/src/Emulator/Cores/RiscV/RiscV64.cs
+++ b/src/Emulator/Cores/RiscV/RiscV64.cs
@@ -4,6 +4,7 @@
 // This file is licensed under the MIT License.
 // Full license text is available in 'licenses/MIT.txt'.
 //
+using System.Collections.Generic;
 using Antmicro.Renode.Core;
 using Antmicro.Renode.Peripherals.Timers;
 using Endianess = ELFSharp.ELF.Endianess;
@@ -20,6 +21,8 @@ namespace Antmicro.Renode.Peripherals.CPU
         public override string Architecture { get { return "riscv64"; } }
 
         public override string GDBArchitecture { get { return "riscv:rv64"; } }
+
+        public override List<GBDFeatureDescriptor> GDBFeatures { get { return new List<GBDFeatureDescriptor>(); } }
 
         protected override byte MostSignificantBit => 63;
 

--- a/src/Emulator/Cores/Sparc/Sparc.cs
+++ b/src/Emulator/Cores/Sparc/Sparc.cs
@@ -32,6 +32,8 @@ namespace Antmicro.Renode.Peripherals.CPU
 
         public override string GDBArchitecture { get { return Architecture; } }
 
+        public override List<GBDFeatureDescriptor> GDBFeatures { get { return new List<GBDFeatureDescriptor>(); } }
+
         private void Init()
         {
 

--- a/src/Emulator/Cores/X86/X86.cs
+++ b/src/Emulator/Cores/X86/X86.cs
@@ -27,6 +27,8 @@ namespace Antmicro.Renode.Peripherals.CPU
 
         public override string GDBArchitecture { get { return Architecture; } }
 
+        public override List<GBDFeatureDescriptor> GDBFeatures { get { return new List<GBDFeatureDescriptor>(); } }
+
         protected override Interrupt DecodeInterrupt(int number)
         {
             if(number == 0)

--- a/src/Emulator/Extensions/Utilities/GDB/Commands/QueryCommand.cs
+++ b/src/Emulator/Extensions/Utilities/GDB/Commands/QueryCommand.cs
@@ -36,7 +36,18 @@ namespace Antmicro.Renode.Utilities.GDB.Commands
             var xmlFile = new StringBuilder();
             if(objectType == "features")
             {
-                xmlFile.Append($"<?xml version=\"1.0\"?>\n<!DOCTYPE target SYSTEM \"gdb-target.dtd\">\n<target version=\"1.0\">\n<architecture>{manager.Cpu.GDBArchitecture}</architecture>\n</target>");
+                xmlFile.Append("<?xml version=\"1.0\"?>\n<!DOCTYPE feature SYSTEM \"gdb-target.dtd\">\n<target version=\"1.0\">\n");
+                xmlFile.Append($"<architecture>{manager.Cpu.GDBArchitecture}</architecture>\n");
+                foreach(var feature in manager.Cpu.GDBFeatures)
+                {
+                    xmlFile.Append($"<feature name=\"{feature.Name}\">\n");
+                    foreach(var register in feature.Registers)
+                    {
+                        xmlFile.Append($"<reg name=\"{register.Name}\" bitsize=\"{register.Size}\" regnum=\"{register.Number}\" type=\"{register.Type}\" group=\"{register.Group}\"/>\n");
+                    }
+                    xmlFile.Append("</feature>\n");
+                }
+                xmlFile.Append("</target>\n");
             }
             else if(objectType == "threads")
             {

--- a/src/Emulator/Extensions/Utilities/GDB/Commands/ReadRegisterCommand.cs
+++ b/src/Emulator/Extensions/Utilities/GDB/Commands/ReadRegisterCommand.cs
@@ -20,17 +20,35 @@ namespace Antmicro.Renode.Utilities.GDB.Commands
         public PacketData Execute(
             [Argument(Encoding = ArgumentAttribute.ArgumentEncoding.HexNumber)]int registerNumber)
         {
-            if(!manager.Cpu.GetRegisters().Any(x => x.Index == registerNumber))
-            {
-                return PacketData.ErrorReply(1);
+            var content = new StringBuilder();
+
+            // if register exists in emulated core return current value of this
+            if(manager.Cpu.GetRegisters().Any(x => x.Index == registerNumber))
+            { 
+                foreach(var b in manager.Cpu.GetRegisterUnsafe(registerNumber).GetBytes())
+                {
+                    content.AppendFormat("{0:x2}", b);
+                }
+                return new PacketData(content.ToString());
             }
 
-            var content = new StringBuilder();
-            foreach(var b in manager.Cpu.GetRegisterUnsafe(registerNumber).GetBytes())
+            // if register no exists in emulated core but is defined in a feature
+            // return a cero value with number of bytes defined in the feature
+            var selectedRegisters = manager.Cpu.GDBFeatures.SelectMany(f => f.Registers)
+                .Where(r => r.Number == registerNumber);
+
+            if(selectedRegisters.Any())
             {
-                content.AppendFormat("{0:x2}", b);
+                for(var b = 0; b < selectedRegisters.First().Size / 8; b++)
+                {
+                    content.AppendFormat("00");
+                }
+                return new PacketData(content.ToString());
             }
-            return new PacketData(content.ToString());
+
+            // else return error
+            return PacketData.ErrorReply(1);
+
         }
     }
 }

--- a/src/Emulator/Main/Peripherals/CPU/ICpuSupportingGdb.cs
+++ b/src/Emulator/Main/Peripherals/CPU/ICpuSupportingGdb.cs
@@ -5,9 +5,40 @@
 // Full license text is available in 'licenses/MIT.txt'.
 //
 using System;
+using System.Collections.Generic;
 
 namespace Antmicro.Renode.Peripherals.CPU
 {
+    public struct GBDRegisterDescriptor
+    {
+        public GBDRegisterDescriptor(uint number, uint size, string name, string type, string group) : this()
+        {
+            this.Number = number;
+            this.Size = size;
+            this.Name = name;
+            this.Type = type;
+            this.Group = group;
+        }
+
+        public uint Number { get; }
+        public uint Size { get; }
+        public string Name { get; }
+        public string Type { get; }
+        public string Group { get; }
+    }
+
+    public struct GBDFeatureDescriptor
+    {
+        public GBDFeatureDescriptor(string name) : this()
+        {
+            this.Name = name;
+            this.Registers = new List<GBDRegisterDescriptor>();
+        }
+
+        public string Name { get; }
+        public List<GBDRegisterDescriptor> Registers { get; }
+    }
+
     public interface ICpuSupportingGdb : ICPUWithHooks, IControllableCPU
     {
         ulong Step(int count = 1);
@@ -16,6 +47,7 @@ namespace Antmicro.Renode.Peripherals.CPU
         void EnterSingleStepModeSafely(HaltArguments args);
 
         string GDBArchitecture { get; }
+        List<GBDFeatureDescriptor> GDBFeatures { get; }
         bool DebuggerConnected { get; set; }
         uint Id { get; }
         string Name { get; }

--- a/src/Emulator/Peripherals/Peripherals/CPU/TranslationCPU.cs
+++ b/src/Emulator/Peripherals/Peripherals/CPU/TranslationCPU.cs
@@ -1066,6 +1066,8 @@ namespace Antmicro.Renode.Peripherals.CPU
 
         public abstract string GDBArchitecture { get; }
 
+        public abstract List<GBDFeatureDescriptor> GDBFeatures { get; }
+
         public bool DebuggerConnected { get; set; }
 
         public uint Id { get; }


### PR DESCRIPTION
In this [message](https://github.com/renode/renode/issues/50#issuecomment-579842875) mentions the need to fully implement the target.xml file on GDB, so that the RISC-V processors can report the specific CRS records. I needed to implement this functionality to be able to properly debug a Cortex-M processor. In this pull request I propose the solution that I implemented to correct it and add it to the project.