### PR TITLE
130 add edu ciaa nxp board

### DIFF
--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -336,6 +336,7 @@
     <Compile Include="Peripherals\Miscellaneous\NRF82540_CLOCK.cs" />
     <Compile Include="Peripherals\Timers\NRF52840_RTC.cs" />
     <Compile Include="Peripherals\GPIOPort\LPC43xx_GPIO.cs" />
+    <Compile Include="Peripherals\Miscellaneous\SevenSegmentsDisplay.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -335,6 +335,7 @@
     <Compile Include="Peripherals\Miscellaneous\STM32F4_RCC.cs" />
     <Compile Include="Peripherals\Miscellaneous\NRF82540_CLOCK.cs" />
     <Compile Include="Peripherals\Timers\NRF52840_RTC.cs" />
+    <Compile Include="Peripherals\GPIOPort\LPC43xx_GPIO.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/LPC43xx_GPIO.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/LPC43xx_GPIO.cs
@@ -1,0 +1,151 @@
+﻿//
+// Copyright (c) 2020 LabMICRO FACET UNT
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Peripherals.Bus;
+using Antmicro.Renode.Utilities;
+
+namespace Antmicro.Renode.Peripherals.GPIOPort
+{
+    public class LPC43xx_GPIO : BaseGPIOPort, IProvidesRegisterCollection<DoubleWordRegisterCollection>, IDoubleWordPeripheral, IKnownSize
+    {
+        public LPC43xx_GPIO(Machine machine) : base(machine, PinsPerPort * NumberOfPorts)
+        {
+            RegistersCollection = new DoubleWordRegisterCollection(this);
+
+            ports = new Port[NumberOfPorts];
+            for(var portNumber = 0; portNumber < ports.Length; portNumber++)
+            {
+                ports[portNumber] = new Port(portNumber, this);
+            }
+
+            Reset();
+        }
+
+        public uint ReadDoubleWord(long offset)
+        {
+            return RegistersCollection.Read(offset);
+        }
+
+        public void WriteDoubleWord(long offset, uint value)
+        {
+            RegistersCollection.Write(offset, value);
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            RegistersCollection.Reset();
+        }
+
+        public long Size => 0x2380;
+
+        public DoubleWordRegisterCollection RegistersCollection { get; }
+
+        private readonly Port[] ports;
+
+        private const int NumberOfPorts = 8;
+        private const int PinsPerPort = 32;
+
+        private class Port
+        {
+            public Port(int portNumber, LPC43xx_GPIO parent)
+            {
+                this.portNumber = portNumber;
+                this.parent = parent;
+
+                parent.RegistersCollection.DefineRegister((uint)Registers.Direction + 4 * portNumber)
+                    .WithValueField(0, PinsPerPort, out direction, name: $"GPIO_DIR{portNumber}",
+                        writeCallback: (_, value) => RefreshConnectionsState());
+
+                parent.RegistersCollection.DefineRegister((uint)Registers.Mask + 4 * portNumber)
+                    .WithValueField(0, PinsPerPort, out mask, name: $"GPIO_MASK{portNumber}");
+
+                parent.RegistersCollection.DefineRegister((uint)Registers.Pin + 4 * portNumber)
+                    .WithValueField(0, PinsPerPort, out state, name: $"GPIO_PIN{portNumber}",
+                        writeCallback: (_, value) => RefreshConnectionsState(),
+                        valueProviderCallback: _ => GetStateValue());
+
+                parent.RegistersCollection.DefineRegister((uint)Registers.MaskedPin + 4 * portNumber)
+                    .WithValueField(0, PinsPerPort, name: $"GPIO_MPIN{portNumber}",
+                        writeCallback: (_, value) => SetStateValue(state.Value & mask.Value | value & ~mask.Value),
+                        valueProviderCallback: _ => GetStateValue() & ~mask.Value);
+
+                parent.RegistersCollection.DefineRegister((uint)Registers.SetPin + 4 * portNumber)
+                    .WithValueField(0, PinsPerPort, name: $"GPIO_SET{portNumber}",
+                        writeCallback: (_, value) => SetStateValue(state.Value | value),
+                        valueProviderCallback: _ => GetStateValue());
+
+                parent.RegistersCollection.DefineRegister((uint)Registers.ClearPin + 4 * portNumber)
+                    .WithValueField(0, PinsPerPort, FieldMode.Write, name: $"GPIO_CLR{portNumber}",
+                        writeCallback: (_, value) => SetStateValue(state.Value & ~value));
+
+                parent.RegistersCollection.DefineRegister((uint)Registers.NegatePin + 4 * portNumber)
+                    .WithValueField(0, PinsPerPort, FieldMode.Write, name: $"GPIO_NOT{portNumber}",
+                        writeCallback: (_, value) => SetStateValue(state.Value ^ value));
+            }
+
+            private UInt32 GetStateValue()
+            {
+                UInt32 result = 0;
+
+                for(byte bitIndex = 0; bitIndex < PinsPerPort; bitIndex++)
+                {
+                    var idx = PinsPerPort * portNumber + bitIndex;
+                    var isOutputPin = BitHelper.IsBitSet(direction.Value, bitIndex);
+
+                    BitHelper.SetBit(ref result, bitIndex, isOutputPin
+                        ? parent.Connections[idx].IsSet
+                        : parent.State[idx]);
+                }
+
+                return result;
+            }
+
+            private void SetStateValue(UInt32 value)
+            {
+                state.Value = value;
+                RefreshConnectionsState();
+            }
+
+            private void RefreshConnectionsState()
+            {
+                for(byte bitIndex = 0; bitIndex < PinsPerPort; bitIndex++)
+                {
+                    if(BitHelper.IsBitSet(direction.Value, bitIndex))
+                    {
+                        var connection = parent.Connections[PinsPerPort * portNumber + bitIndex];
+                        var pinState = BitHelper.IsBitSet(state.Value, bitIndex);
+
+                        connection.Set(pinState);
+                    }
+                }
+            }
+
+            private readonly int portNumber;
+            private readonly IValueRegisterField direction;
+            private readonly IValueRegisterField mask;
+            private readonly IValueRegisterField state;
+
+            private readonly LPC43xx_GPIO parent;
+        }
+
+        private enum Registers
+        {
+            Direction = 0x2000,
+            Mask = 0x2080,
+            Pin = 0x2100,
+            MaskedPin = 0x2180,
+            SetPin = 0x2200,
+            ClearPin = 0x2280,
+            NegatePin = 0x2300,
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/SevenSegmentsDisplay.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/SevenSegmentsDisplay.cs
@@ -1,0 +1,207 @@
+﻿//
+// Copyright (c) 2020 LabMICRO FACET UNT
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using System.Linq;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Logging;
+using Antmicro.Migrant;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Antmicro.Renode.Peripherals.Miscellaneous
+{
+    // This class implements an multiplexed seven segment display with a variable number of digits 
+    // First eighths input gpio lines are used to handle from "a" to "f" segments and dot point
+    // Remaining input gpio lines are used to enable each of digits starting from left
+    // To activate a segment, the digit and segment gpio inputs must be set to true
+    // Anode and catode common displays can be emulated with invertSegments and invertDigits parameters
+
+    public class SevenSegmentsDisplay : IGPIOReceiver
+    {
+        public SevenSegmentsDisplay(uint digitsCount = 1, bool invertSegments = false, bool invertDigits = false)
+        {
+            this.invertSegments = invertSegments;
+            this.invertDigits = invertDigits;
+
+            digit = new Digit();
+            enabledDigits = new bool[digitsCount];
+
+            sync = new object();
+            Reset();
+        }
+
+        public void Reset()
+        {
+            digit.Clear();
+            for(var index = 0; index < enabledDigits.Length; index++)
+            {
+                enabledDigits[index] = invertDigits;
+            }
+
+            Update();
+        }
+
+        public void OnGPIO(int number, bool value)
+        {
+            if(number >= 0 && number < SegmentsCount)
+            {
+                digit.SetSegment((Segments)(1 << number), invertSegments ? !value : value);
+            }
+            else if(number >= SegmentsCount && number - SegmentsCount < enabledDigits.Length)
+            {
+                enabledDigits[number - SegmentsCount] = invertDigits ? !value : value;
+            }
+            else
+            {
+                this.Log(LogLevel.Error, "This device can handle GPIOs in range 0 - {0}, but {1} was set", SegmentsCount + enabledDigits.Length, number);
+                return;
+            }
+
+            Update();
+        }
+
+        [field: Transient]
+        public event Action<IPeripheral, string> StateChanged;
+
+        public string Image { get; private set; }
+
+        public string State { get; private set; }
+        
+        private void Update()
+        {
+            lock(sync)
+            {              
+                var newState = AsSegmentsString();
+                if(newState == State)
+                {
+                    return;
+                }
+
+                State = newState;
+                Image = AsPrettyString();
+
+                StateChanged?.Invoke(this, State);
+
+                this.Log(LogLevel.Noisy, "Seven Segments state changed to {0} {1}", State, Image);
+            }
+        }
+
+        private string AsPrettyString()
+        {
+            var result = new StringBuilder();
+
+            result.Append("(");
+            foreach(var isEnabled in enabledDigits)
+            {
+                result.Append(isEnabled
+                    ? digit.AsString()
+                    : "_");
+            }
+            result.Append(")");
+
+            return result.ToString();
+        }
+
+        private string AsSegmentsString()
+        {
+            var result = new StringBuilder();
+
+            foreach(var isEnabled in enabledDigits)
+            {
+                result.Append("[");
+                if(isEnabled)
+                {
+                    result.Append(digit.Value.ToString());
+                }
+                result.Append("]");
+            }
+            return result.ToString();
+        }
+
+        private readonly Digit digit;
+        private readonly bool[] enabledDigits;
+
+        private readonly bool invertSegments;
+        private readonly bool invertDigits;
+        private readonly object sync;
+
+        private const int SegmentsCount = 8;
+
+        [Flags]
+        private enum Segments
+        {
+            A = 1 << 0,
+            B = 1 << 1,
+            C = 1 << 2,
+            D = 1 << 3,
+            E = 1 << 4,
+            F = 1 << 5,
+            G = 1 << 6,
+            DOT = 1 << 7
+        }
+
+        private class Digit
+        {
+            public Segments Value { get; private set; }
+
+            public void SetSegment(Segments segment, bool asOn)
+            {
+                if(asOn)
+                {
+                    Value |= segment;
+                }
+                else
+                {
+                    Value &= ~segment;
+                }
+            }
+
+            public void Clear()
+            {
+                Value = 0;
+            }
+
+            public string AsString()
+            {
+                var hasDot = (Value & Segments.DOT) == Segments.DOT;
+
+                if(!SegmentsToStringMapping.TryGetValue(Value & ~Segments.DOT, out var result))
+                {
+                    result = "?";
+                }
+
+                if(hasDot)
+                {
+                    result += ".";
+                }
+
+                return result;
+            }
+
+            private static readonly Dictionary<Segments, string> SegmentsToStringMapping = new Dictionary<Segments, string>()
+            {
+                { Segments.A | Segments.B | Segments.C | Segments.D | Segments.E | Segments.F             , "0" },
+                {              Segments.B | Segments.C                                                    , "1" },
+                { Segments.A | Segments.B |              Segments.D | Segments.E |              Segments.G, "2" },
+                { Segments.A | Segments.B | Segments.C | Segments.D |                           Segments.G, "3" },
+                {              Segments.B | Segments.C |                           Segments.F | Segments.G, "4" },
+                { Segments.A |              Segments.C | Segments.D |              Segments.F | Segments.G, "5" },
+                { Segments.A |              Segments.C | Segments.D | Segments.E | Segments.F | Segments.G, "6" },
+                { Segments.A | Segments.B | Segments.C                                                    , "7" },
+                { Segments.A | Segments.B | Segments.C | Segments.D | Segments.E | Segments.F | Segments.G, "8" },
+                { Segments.A | Segments.B | Segments.C | Segments.D |              Segments.F | Segments.G, "9" },
+                { Segments.A | Segments.B | Segments.C |              Segments.E | Segments.F | Segments.G, "A" },
+                {                           Segments.C | Segments.D | Segments.E | Segments.F | Segments.G, "B" },
+                { Segments.A |                           Segments.D | Segments.E | Segments.F             , "C" },
+                {              Segments.B | Segments.C | Segments.D | Segments.E |              Segments.G, "D" },
+                { Segments.A |                           Segments.D | Segments.E | Segments.F | Segments.G, "E" },
+                { Segments.A |                                        Segments.E | Segments.F | Segments.G, "F" },
+            };
+        }
+    }
+}
+

--- a/src/Emulator/Peripherals/Test/PeripheralsTests/LPC43xx_GPIO_Test.cs
+++ b/src/Emulator/Peripherals/Test/PeripheralsTests/LPC43xx_GPIO_Test.cs
@@ -1,0 +1,189 @@
+//
+// Copyright (c) 2010-2020 LabMICRO FACET UNT
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using NUnit.Framework;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Peripherals.GPIOPort;
+using Antmicro.Renode.Peripherals.Bus;
+
+namespace Antmicro.Renode.PeripheralsTests
+{
+    [TestFixture]
+    public class LPC43xx_GPIO_Test
+    {
+        [Test]
+        public void InitTest()
+        {
+            var machine = new Machine();
+            var gpio = new LPC43xx_GPIO(machine);
+            machine.SystemBus.Register(gpio, new BusRangeRegistration(0x4000A000, 0x400));
+
+            // Given a just reseted gpio port
+            gpio.Reset();
+
+            for(var port = 0; port < 8; port ++)
+            {
+                // Then GPIO_DIR should have a value equal to cero
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_DIR + 4 * port), 0x00000000);
+                // And GPIO_MASK should have a value equal to cero
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_MASK + 4 * port), 0x00000000);
+                // And GPIO_SET should have a value equal to cero
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_SET + 4 * port), 0x00000000);
+            }
+        }
+
+        [Test]
+        public void ChangeDirectionToOutput()
+        {
+            var machine = new Machine();
+            var gpio = new LPC43xx_GPIO(machine);
+            machine.SystemBus.Register(gpio, new BusRangeRegistration(0x4000A000, 0x400));
+
+            // Given a just reseted gpio port
+            gpio.Reset();
+
+            for(var port = 0; port < 8; port++)
+            {
+                // When GPIO_DIR it's written to set all pins as outputs
+                gpio.WriteDoubleWord(GPIO_DIR + 4 * port, 0xFFFFFFFF);
+                // Then GPIO_DIR should confirm that all pins are outpus
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_DIR + 4 * port), 0xFFFFFFFF);
+                // And GPIO_MASK should have retained the reset value
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_MASK + 4 * port), 0x00000000);
+                // And GPIO_PIN should have retained the reset value
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_PIN + 4 * port), 0x00000000);
+                // And  GPIO_MPIN should have retained the reset value
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_MPIN + 4 * port), 0x00000000);
+                // And  GPIO_SET should have retained the reset value
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_SET + 4 * port), 0x00000000);
+            }
+        }
+
+        [Test]
+        public void ChangeOutputsState()
+        {
+            var machine = new Machine();
+            var gpio = new LPC43xx_GPIO(machine);
+            machine.SystemBus.Register(gpio, new BusRangeRegistration(0x4000A000, 0x400));
+
+            gpio.Reset();
+            for(var port = 0; port < 8; port++)
+            {
+                // Given a gpio port with all pins configured as outputs
+                gpio.WriteDoubleWord(GPIO_DIR + 4 * port, 0xFFFFFFFF);
+
+                // When GPIO_PIN are writed to set all outpus pins to high state
+                gpio.WriteDoubleWord(GPIO_PIN + 4 * port, 0xFFFFFFFF);
+                // Then GPIO_PIN should have the current value of the outputs
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_PIN + 4 * port), 0xFFFFFFFF);
+                // And GPIO_SET should have the current value of the outputs
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_SET + 4 * port), 0xFFFFFFFF);
+
+                // When GPIO_PIN are writed to set all outpus pins to low state
+                gpio.WriteDoubleWord(GPIO_PIN + 4 * port, 0x00000000);
+                // Then GPIO_PIN should have the current value of the outputs
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_PIN + 4 * port), 0x00000000);
+                // And GPIO_SET should have the current value of the outputs
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_SET + 4 * port), 0x00000000);
+
+                // When GPIO_SET are writed to set all outpus pins to high state
+                gpio.WriteDoubleWord(GPIO_SET + 4 * port, 0xFFFFFFFF);
+                // Then GPIO_PIN should have the current value of the outputs
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_PIN + 4 * port), 0xFFFFFFFF);
+
+                // When GPIO_SET are writed to not produce changes in the outputs
+                gpio.WriteDoubleWord(GPIO_SET + 4 * port, 0x00000000);
+                // Then GPIO_PIN should have retained the previous value of the outputs
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_PIN + 4 * port), 0xFFFFFFFF);
+
+                // When GPIO_CLR are writed to set all outpus pins to low state
+                gpio.WriteDoubleWord(GPIO_CLR + 4 * port, 0xFFFFFFFF);
+                // Then GPIO_PIN should have the current value of the outputs
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_PIN + 4 * port), 0x00000000);
+
+                // When GPIO_SET are writed to not produce changes in the outputs
+                gpio.WriteDoubleWord(GPIO_CLR + 4 * port, 0x00000000);
+                // Then GPIO_PIN should have retained the previous value of the outputs
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_PIN + 4 * port), 0x00000000);
+
+                // When GPIO_NOT are writed to change all outpus pins
+                gpio.WriteDoubleWord(GPIO_NOT + 4 * port, 0xFFFFFFFF);
+                // Then GPIO_PIN should have the current value of the outputs
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_PIN + 4 * port), 0xFFFFFFFF);
+
+                // When GPIO_NOT are writed to change all outpus pins
+                gpio.WriteDoubleWord(GPIO_NOT + 4 * port, 0xFFFFFFFF);
+                // Then GPIO_PIN should have the current value of the outputs
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_PIN + 4 * port), 0x00000000);
+
+                // When GPIO_NOT are writed to to not produce changes in the outputs
+                gpio.WriteDoubleWord(GPIO_NOT + 4 * port, 0x00000000);
+                // Then GPIO_PIN should have retained the previous value of the outputs
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_PIN + 4 * port), 0x00000000);
+            }
+        }
+
+        [Test]
+        public void ChangeMask()
+        {
+            var machine = new Machine();
+            var gpio = new LPC43xx_GPIO(machine);
+            machine.SystemBus.Register(gpio, new BusRangeRegistration(0x4000A000, 0x400));
+
+            gpio.Reset();
+            for(var port = 0; port < 8; port++)
+            {
+                // When GPIO_MASK it's written to set filter out all pins
+                gpio.WriteDoubleWord(GPIO_MASK + 4 * port, 0xFFFFFFFF);
+                // Then GPIO_MASK should confirm that all pins are filtered out
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_MASK + 4 * port), 0xFFFFFFFF);
+            }
+        }
+
+        [Test]
+        public void ChangeMaskedOuputState()
+        {
+            var machine = new Machine();
+            var gpio = new LPC43xx_GPIO(machine);
+            machine.SystemBus.Register(gpio, new BusRangeRegistration(0x4000A000, 0x400));
+
+            gpio.Reset();
+            for(var port = 0; port < 8; port++)
+            {
+                // Given a gpio port with all pins configured as outputs
+                gpio.WriteDoubleWord(GPIO_DIR + 4 * port, 0xFFFFFFFF);
+                // And a gpio port with all pins setted to high state
+                gpio.WriteDoubleWord(GPIO_PIN + 4 * port, 0xFFFFFFFF);
+
+                // When GPIO_MASK it's written to set filter out lower half pins
+                gpio.WriteDoubleWord(GPIO_MASK + 4 * port, 0x0000FFFF);
+                // Then GPIO_MPORT should return filtered pins in low and not filtered pins in high
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_MPIN + 4 * port), 0xFFFF0000);
+
+                // When GPIO_MPORT it's written to set filter pins to low
+                gpio.WriteDoubleWord(GPIO_MPIN + 4 * port, 0x00000000);
+                // Then GPIO_PORT should return not filtered pins in low and filtered pins in high
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_PIN + 4 * port), 0x0000FFFF);
+
+                // When GPIO_MASK it's written to set filter out upper half pins
+                gpio.WriteDoubleWord(GPIO_MASK + 4 * port, 0xFFFF0000);
+                // Then GPIO_MPORT should return filtered pins in low and not filtered pins in high
+                Assert.AreEqual(gpio.ReadDoubleWord(GPIO_MPIN + 4 * port), 0x0000FFFF);
+            }
+        }
+
+        private const uint GPIO_DIR = 0x2000;
+        private const uint GPIO_MASK = 0x2080;
+        private const uint GPIO_PIN = 0x2100;
+        private const uint GPIO_MPIN = 0x2180;
+        private const uint GPIO_SET = 0x2200;
+        private const uint GPIO_CLR = 0x2280;
+        private const uint GPIO_NOT = 0x2300;
+
+    }
+}
+

--- a/src/Emulator/Peripherals/Test/PeripheralsTests/PeripheralsTests.csproj
+++ b/src/Emulator/Peripherals/Test/PeripheralsTests/PeripheralsTests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="BMC050Test.cs" />
     <Compile Include="STMCANTest.cs" />
     <Compile Include="GailserUARTTests.cs" />
+    <Compile Include="LPC43xx_GPIO_Test.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
The GPIO port of the NXP LPC43xx processors and a multiplexed seven segments display are implemented, necessary to be able to add the EDU-CIAA-NXP board that uses these devices.