### PR TITLE
[#154] add version option

### DIFF
--- a/src/UI/CommandLineInterface.cs
+++ b/src/UI/CommandLineInterface.cs
@@ -32,6 +32,12 @@ namespace Antmicro.Renode.UI
         {
             AppDomain.CurrentDomain.UnhandledException += (sender, e) => CrashHandler.HandleCrash((Exception)e.ExceptionObject);
 
+            if(options.Version)
+            {
+                Console.Out.WriteLine(EmulationManager.Instance.VersionString);
+                return;
+            }
+
             if(!options.HideLog)
             {
                 Logger.AddBackend(ConsoleBackend.Instance, "console");

--- a/src/UI/Options.cs
+++ b/src/UI/Options.cs
@@ -43,6 +43,9 @@ namespace Antmicro.Renode.UI
         [Name("robot-debug-on-error"), DefaultValue(false), Description("Initialize GUI for Robot tests debugging")]
         public bool RobotDebug { get; set; }
 
+        [Name('v', "version"), DefaultValue(false), Description("Print version and exit.")]
+        public bool Version { get; set; }
+
         public bool Validate(out string error)
         {
             if(DisableXwt)


### PR DESCRIPTION
This adds `-v|--version` to the Renode command line interface. It prints the version to stdout and directly exits.

Fixes https://github.com/renode/renode/issues/154.