### PR TITLE
[#155] efr32_usart: set flag in async mode

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/UART/EFR32_USART.cs
+++ b/src/Emulator/Peripherals/Peripherals/UART/EFR32_USART.cs
@@ -215,9 +215,11 @@ namespace Antmicro.Renode.Peripherals.UART
             }
             else
             {
+                transferCompleteFlag.Value = false;
                 interruptsManager.SetInterrupt(Interrupt.TransmitBufferLevel);
-                interruptsManager.SetInterrupt(Interrupt.TransmitComplete);
                 TransmitCharacter(data);
+                transferCompleteFlag.Value = true;
+                interruptsManager.SetInterrupt(Interrupt.TransmitComplete);
             }
         }
 


### PR DESCRIPTION
This toggles transferCompleteFlag in asynchronous mode. I've made sure that the register value is updated before the interrupt is raised.

Fixes https://github.com/renode/renode/issues/155