### PR TITLE
[GH#148] Adding a simple way to configure an IPv4 network with DHCP in Linux from Renode

### DIFF
--- a/src/Emulator/Extensions/Extensions.csproj
+++ b/src/Emulator/Extensions/Extensions.csproj
@@ -172,6 +172,12 @@
     <Compile Include="UserInterface\Commands\LastLogCommand.cs" />
     <Compile Include="UserInterface\Commands\DisplayImageCommand.cs" />
     <Compile Include="Hooks\InterruptPythonEngine.cs" />
+    <Compile Include="TAPHelper\TapIPHelper.cs" />
+    <Compile Include="HostInterfaces\Network\LinuxHostIPv4Config.cs" />
+    <Compile Include="HostInterfaces\Network\LinuxIPv4RoutingPolicy.cs" />
+    <Compile Include="HostInterfaces\Network\ILinuxHostConfig.cs" />
+    <Compile Include="HostInterfaces\Network\LinuxHostConfigurator.cs" />
+    <Compile Include="HostInterfaces\Network\LinuxDnsmasqServer.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/src/Emulator/Extensions/HostInterfaces/Network/ILinuxHostConfig.cs
+++ b/src/Emulator/Extensions/HostInterfaces/Network/ILinuxHostConfig.cs
@@ -1,0 +1,17 @@
+﻿//
+// Copyright (c) 2010-2020 Antmicro
+//
+//  This file is licensed under the MIT License.
+//  Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using System.IO;
+
+namespace Antmicro.Renode.HostInterfaces.Network
+{
+    public interface ILinuxHostConfig
+    {
+        void Apply(StreamWriter shellFile);
+        void Rewoke(StreamWriter shellFile);
+    }
+}

--- a/src/Emulator/Extensions/HostInterfaces/Network/LinuxDnsmasqServer.cs
+++ b/src/Emulator/Extensions/HostInterfaces/Network/LinuxDnsmasqServer.cs
@@ -1,0 +1,76 @@
+﻿//
+// Copyright (c) 2010-2018 Antmicro
+// Copyright (c) 2011-2015 Realtime Embedded
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+using System.IO;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.TAPHelper;
+using Antmicro.Renode.Utilities;
+
+namespace Antmicro.Renode.HostInterfaces.Network
+{
+    public class LinuxDnsmasqServer : IHostMachineElement, ILinuxHostConfig
+    {
+        public LinuxDnsmasqServer(string bridgeName, string iP, string dhcpRangeStart, string dhcpRangeEnd)
+        {
+            this.IsEnabled = TapIPHelper.IsValidIPv4(dhcpRangeStart) &&
+                        TapIPHelper.IsValidIPv4(dhcpRangeEnd);
+
+            if(!this.IsEnabled)
+            {
+                this.Log(LogLevel.Info, "No valid DHCP range specified. DHCP is disabled");
+            }
+
+            if (!TapIPHelper.IsValidIPv4(iP))
+            {
+                this.Log(LogLevel.Info, "No valid IP for the DHCP interface. DHCP is disabled.");
+                this.IsEnabled = false;
+            }
+
+            this.bridgeName = bridgeName;
+            this.iP = iP;
+            this.dhcpRangeStart = dhcpRangeStart;
+            this.dhcpRangeEnd = dhcpRangeEnd;
+            this.pidFile = TemporaryFilesManager.Instance.GetTemporaryFile();
+
+            if (this.IsEnabled)
+            {
+                this.Log(LogLevel.Info, "DHCP Server enabled");
+            }
+        }
+
+        public void Apply(StreamWriter shellFile)
+        {
+            if(!this.IsEnabled) return;
+
+            var arguments = string.Format("dnsmasq --log-queries --no-hosts --no-resolv --leasefile-ro --interface={0} -p0 --log-dhcp --dhcp-range={1},{2} -x {3}",
+                                                                    this.bridgeName,
+                                                                    this.dhcpRangeStart,
+                                                                    this.dhcpRangeEnd,
+                                                                    this.pidFile);
+
+            shellFile.WriteLine(arguments);
+        }
+
+        public void Rewoke(StreamWriter shellFile)
+        {
+            if(!this.IsEnabled) return;
+            this.IsEnabled = false;
+
+            string killString = string.Format("pkill -F {0}", this.pidFile);
+            shellFile.WriteLine(killString);
+        }
+
+        public bool IsEnabled { get; private set; }
+
+        private string bridgeName;
+        private string iP;
+        private string dhcpRangeStart;
+        private string dhcpRangeEnd;
+        private string pidFile;
+    }
+}

--- a/src/Emulator/Extensions/HostInterfaces/Network/LinuxHostConfigurator.cs
+++ b/src/Emulator/Extensions/HostInterfaces/Network/LinuxHostConfigurator.cs
@@ -1,0 +1,108 @@
+﻿//
+// Copyright (c) 2010-2018 Antmicro
+// Copyright (c) 2011-2015 Realtime Embedded
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Exceptions;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Utilities;
+
+namespace Antmicro.Renode.HostInterfaces.Network
+{
+    public class LinuxHostConfigurator : IHostMachineElement, IDisposable
+    {
+        public LinuxHostConfigurator()
+        {
+            configs = new List<ILinuxHostConfig>();
+        }
+
+        public void ApplyHostConfiguration()
+        {
+            this.Log(LogLevel.Info, "Applying host network configuration");
+
+            var generatedFileName = TemporaryFilesManager.Instance.GetTemporaryFile();
+            this.Log(LogLevel.Info, "Shell file {0}", generatedFileName);
+
+            using(StreamWriter configFile = new StreamWriter(generatedFileName))
+            {
+                foreach(var cfg in configs)
+                {
+                    cfg.Apply(configFile);
+                }
+            }
+            RunShellScript(generatedFileName);
+        }
+
+        public void Register(ILinuxHostConfig config)
+        {
+            configs.Add(config);
+        }
+
+        public void Dispose()
+        {
+            if(configs.Count == 0) return;
+            this.Log(LogLevel.Info, "Rewoking host network configuration");
+            configs.Reverse();
+
+            var generatedFileName = TemporaryFilesManager.Instance.GetTemporaryFile();
+            this.Log(LogLevel.Debug, "Shell file {0}", generatedFileName);
+
+            using(StreamWriter configFile = new StreamWriter(generatedFileName))
+            {
+                foreach(var cfg in configs)
+                {
+                    cfg.Rewoke(configFile);
+                }
+            }
+
+            RunShellScript(generatedFileName);
+            configs.Clear();
+        }
+
+        private void RunShellScript(string generatedFileName)
+        {
+            var process = new Process();
+            var output = string.Empty;
+            process.StartInfo.FileName = "/bin/bash";
+            process.StartInfo.Arguments = string.Format("-e {0}", generatedFileName);
+
+            try
+            {
+                SudoTools.EnsureSudoProcess(process, "Renode Linux IPv4 Network");
+            }
+            catch(Exception ex)
+            {
+                throw new RecoverableException("Process elevation failed: " + ex.Message);
+            }
+
+            process.EnableRaisingEvents = true;
+            process.StartInfo.CreateNoWindow = false;
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.RedirectStandardOutput = true;
+
+            var started = process.Start();
+            if(started)
+            {
+                output = process.StandardError.ReadToEnd();
+                process.WaitForExit();
+            }
+
+            if(!started || process.ExitCode != 0)
+            {
+                this.Log(LogLevel.Error, "Could not apply configuration file.");
+                this.Log(LogLevel.Warning, "Exit code {0} Encountered error {1}", process.ExitCode, output);
+                return;
+            }
+        }
+
+        private List<ILinuxHostConfig> configs;
+    }
+}

--- a/src/Emulator/Extensions/HostInterfaces/Network/LinuxHostIPv4Config.cs
+++ b/src/Emulator/Extensions/HostInterfaces/Network/LinuxHostIPv4Config.cs
@@ -1,0 +1,73 @@
+﻿//
+// Copyright (c) 2010-2020 Antmicro
+//
+//  This file is licensed under the MIT License.
+//  Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using System.Diagnostics;
+using System.IO;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Exceptions;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.TAPHelper;
+using Antmicro.Renode.Utilities;
+
+namespace Antmicro.Renode.HostInterfaces.Network
+{
+    public class LinuxHostIPv4Config : IEmulationElement, ILinuxHostConfig
+    {
+        public LinuxHostIPv4Config(string tapName, string ip, uint netmask = 24, string bridgeName = "")
+        {
+            if(!TapIPHelper.IsValidIPv4(ip))
+            {
+                this.Log(LogLevel.Error, "IP provided for TAP config is not a valid IPv4 address.");
+                return;
+            }
+            this.IP = ip;
+
+            if(32 < netmask)
+            {
+                this.Log(LogLevel.Error, "Invalid netmask provided for TAP config. Netmask needs to be between 0 and 32.");
+                return;
+            }
+
+            this.Netmask = netmask;
+
+            if ("" == bridgeName)
+            {
+                this.Bridge = string.Format("renode-br{0}", EmulationManager.Instance.CurrentEmulation.RandomGenerator.Next(1000,9999));
+            }
+            else
+            {
+                this.Bridge = bridgeName;
+            }
+            this.Log(LogLevel.Info, "Creating bridge {0}", this.Bridge);
+
+            this.TapName = tapName;
+        }
+
+        public void Apply(StreamWriter shellFile)
+        {
+            shellFile.WriteLine(string.Format("ip link add name {0} type bridge", this.Bridge));
+            shellFile.WriteLine(string.Format("ip addr add {0}/{1} brd + dev {2}", this.IP, this.Netmask, this.Bridge));
+            shellFile.WriteLine(string.Format("ip link set {0} up", this.Bridge));
+            shellFile.WriteLine(string.Format("ip link set {0} master {1}", this.TapName, this.Bridge));
+            shellFile.WriteLine(string.Format("ip link set {0} up", this.TapName));
+        }
+
+        public void Rewoke(StreamWriter shellFile)
+        {
+            shellFile.WriteLine(string.Format("ip link delete {0}", this.Bridge));
+            shellFile.WriteLine(string.Format("ip link set {0} down", this.TapName));
+        }
+
+        public string IP { get; private set; }
+        public uint Netmask { get; private set; }
+        public string Bridge { get; private set; }
+        public string TapName{ get; private set; }
+
+        private uint MinID => 1000;
+        private uint MaxID => 9999;
+    }
+}

--- a/src/Emulator/Extensions/HostInterfaces/Network/LinuxIPv4RoutingPolicy.cs
+++ b/src/Emulator/Extensions/HostInterfaces/Network/LinuxIPv4RoutingPolicy.cs
@@ -1,0 +1,63 @@
+﻿//
+// Copyright (c) 2010-2020 Antmicro
+//
+//  This file is licensed under the MIT License.
+//  Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using System.IO;
+using Antmicro.Renode.Logging;
+
+namespace Antmicro.Renode.HostInterfaces.Network
+{
+    public class LinuxIPv4RoutingPolicy: IEmulationElement, ILinuxHostConfig
+    {
+        public LinuxIPv4RoutingPolicy(string bridgeName, string forwardMode, string forwardDevice)
+        {
+            ForwardMode t_mode;
+
+            if(Enum.TryParse(forwardMode, true, out t_mode))
+            {
+                this.Mode = t_mode;
+            }
+            else
+            {
+                this.Log(LogLevel.Error, "Invalid Forward Mode. Forwarding disabled.");
+                this.Mode = ForwardMode.Manual;
+            }
+
+            this.IsEnabled = !(ForwardMode.Manual == this.Mode);
+            this.TargetDevice = forwardDevice;
+            this.Bridge = bridgeName;
+        }
+
+        public void Apply(StreamWriter shellFile)
+        {
+            if(!this.IsEnabled) return;
+
+            shellFile.WriteLine(string.Format("ufw allow in on {0}", this.Bridge));
+            shellFile.WriteLine(string.Format("ufw allow out on {0}", this.Bridge));
+        }
+
+        public void Rewoke(StreamWriter shellFile)
+        {
+            if(!this.IsEnabled) return;
+
+            shellFile.WriteLine(string.Format("ufw delete allow in on {0}", this.Bridge));
+            shellFile.WriteLine(string.Format("ufw delete allow out on {0}", this.Bridge));
+        }
+
+        public enum ForwardMode
+        {
+            Private = 0,
+            NAT = 1,
+            PassThrough = 2,
+            Manual = 3
+        }
+
+        public bool IsEnabled { get; private set; }
+        public ForwardMode Mode { get; private set; }
+        public string TargetDevice { get; private set; }
+        public string Bridge { get; private set; }
+    }
+}

--- a/src/Emulator/Extensions/HostInterfaces/Network/TapExtensions.cs
+++ b/src/Emulator/Extensions/HostInterfaces/Network/TapExtensions.cs
@@ -42,6 +42,40 @@ namespace Antmicro.Renode.HostInterfaces.Network
         {
             CreateAndGetTap(emulation, hostInterfaceName, name, persistent);
         }
+
+#if PLATFORM_LINUX
+        public static void CreateIPv4Network(this Emulation emulation,
+                                        string ip, uint netmask = 24,
+                                        string dhcpRangeStart = "", string dhcpRangeEnd = "",
+                                        string forwardMode = "Private", string forwardDevice = "",
+                                        uint tapId = 0)
+        {
+            string hostInterfaceName = string.Format("tap{0}", tapId);
+            string emulationTapName = string.Format("tap{0}",tapId);
+            CreateTap(emulation, hostInterfaceName, emulationTapName, false);
+
+            string ipv4ConnName = string.Format("ipv4Conn-{0}", tapId);
+            LinuxHostConfigurator lhc = new LinuxHostConfigurator();
+
+            // create the IPv4 config
+            string bridgeName = string.Format("renode-br{0}", tapId);
+            LinuxHostIPv4Config lhIPv4c = new LinuxHostIPv4Config(hostInterfaceName, ip, netmask, bridgeName);
+            lhc.Register(lhIPv4c);
+
+            // create the routing policy
+            LinuxIPv4RoutingPolicy routingPolicy = new LinuxIPv4RoutingPolicy(lhIPv4c.Bridge, forwardMode, forwardDevice);
+            lhc.Register(routingPolicy);
+
+            // Create the DHCP Server
+            LinuxDnsmasqServer dhcpSrv = new LinuxDnsmasqServer(bridgeName, lhIPv4c.IP, dhcpRangeStart, dhcpRangeEnd);
+            lhc.Register(dhcpSrv);
+
+            // apply the changes to the host
+            lhc.ApplyHostConfiguration();
+            emulation.HostMachine.AddHostMachineElement(lhc, ipv4ConnName);
+        }
+#endif
+
     }
 }
 

--- a/src/Emulator/Extensions/TAPHelper/TapIPHelper.cs
+++ b/src/Emulator/Extensions/TAPHelper/TapIPHelper.cs
@@ -1,0 +1,34 @@
+﻿//
+// Copyright (c) 2010-2020 Antmicro
+//
+//  This file is licensed under the MIT License.
+//  Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using System.Net;
+
+namespace Antmicro.Renode.TAPHelper
+{
+    public class TapIPHelper
+    {
+        public static bool IsValidIPv4(string input)
+        {
+            return IsValidIP(input, false);
+        }
+
+        public static bool IsValidIPv6(string input)
+        {
+            return IsValidIP(input, true);
+        }
+
+        private static bool IsValidIP(string input, bool ipv6 = false)
+        {
+            IPAddress address;
+            if(!IPAddress.TryParse(input, out address)) return false;
+
+            if(ipv6) return (System.Net.Sockets.AddressFamily.InterNetworkV6 == address.AddressFamily);
+            return (System.Net.Sockets.AddressFamily.InterNetwork == address.AddressFamily);
+        }
+
+    }
+}


### PR DESCRIPTION
This commit adds support to configure an IPv4 network, including DHCP under Linux.
It requires the packages
* iproute2 (for the ip tool)
* dnsmasq (DHCP)
* procps (for pkill)
* ufw (for configuring the traffic to/from the network interface)

This implementation aims to address the some of the issues described in https://github.com/renode/renode/issues/148