### PR TITLE
Add OpenTitan Software Test Status Model.

### DIFF
--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -367,6 +367,7 @@
     <Compile Include="Peripherals\SPI\PULP_uDMA_SPI.cs" />
     <Compile Include="Peripherals\Mocks\DummySPISlave.cs" />
     <Compile Include="Peripherals\SD\PULP_uDMA_SDIO.cs" />
+    <Compile Include="Peripherals\Miscellaneous\OpenTitan_VerilatorSwTestStatus.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/OpenTitan_VerilatorSwTestStatus.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/OpenTitan_VerilatorSwTestStatus.cs
@@ -1,0 +1,71 @@
+//
+// Copyright (c) 2010-2021 Antmicro
+//
+//  This file is licensed under the MIT License.
+//  Full license text is available in 'licenses/MIT.txt'.
+//
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Logging;
+
+
+namespace Antmicro.Renode.Peripherals.Miscellaneous
+{
+    public class OpenTitan_VerilatorSwTestStatus : BasicDoubleWordPeripheral, IKnownSize
+    {
+        public OpenTitan_VerilatorSwTestStatus(Machine machine) : base(machine)
+        {
+                DefineRegisters();
+        }
+
+        public long Size =>  0x8;
+
+        private enum SoftwareTestStatusCode : uint
+        {
+                kTestStatusDefault = 0x0000,
+                kTestStatusInBootRom = 0xb090,  // 'bogo', BOotrom GO
+                kTestStatusInTest = 0x4354,  // 'test'
+                kTestStatusInWfi = 0x1d1e,  // 'idle'
+                kTestStatusPassed = 0x900d,  // 'good'
+                kTestStatusFailed = 0xbaad  // 'baad'
+        }
+
+        private void DefineRegisters()
+        {
+                Registers.SoftwareTestStatus.Define(this, 0x0)
+                    .WithValueField(0, 16, name: "software test status", writeCallback: (_, value) =>
+                    {
+                        this.Log(LogLevel.Info, "Opentitan Software test status set to 0x{0:x}", value);
+                        bool enumTestStatisIsDefined = System.Enum.IsDefined(typeof(SoftwareTestStatusCode), value);
+                        if (enumTestStatisIsDefined) {
+                                SoftwareTestStatusCode statusCode = (SoftwareTestStatusCode)value;
+                                switch (statusCode) {
+                                        case SoftwareTestStatusCode.kTestStatusInBootRom: 
+                                                this.Log(LogLevel.Info, "Opentitan in boot ROM");
+                                                break;
+                                        case SoftwareTestStatusCode.kTestStatusInTest:
+                                                this.Log(LogLevel.Info, "Opentitan in test");
+                                                break;
+                                        case SoftwareTestStatusCode.kTestStatusInWfi:
+                                                this.Log(LogLevel.Info, "Opentitan in WFI");
+                                                break;
+                                        case SoftwareTestStatusCode.kTestStatusPassed:
+                                                this.Log(LogLevel.Info, "Opentitan PASSED Test");
+                                                break;
+                                        case SoftwareTestStatusCode.kTestStatusFailed:
+                                                this.Log(LogLevel.Info, "Opentitan FAILED Test");
+                                                break;
+                                }
+                        }
+                    })
+                    .WithIgnoredBits(16,16)
+                ;
+        }
+
+        private enum Registers
+        {
+            SoftwareTestStatus = 0x0
+        }
+
+    }
+}


### PR DESCRIPTION
* The OpenTitan test suites use a small amount of memory mapped registers to communicate with the environment.
*  The verilog models are here: https://github.com/lowRISC/opentitan/tree/master/hw/dv/sv/sw_test_status
* OpenTitan contains this software interface: https://github.com/lowRISC/opentitan/blob/master/sw/device/lib/testing/test_status.h