### PR TITLE
Add Ibex 32-bit RISC-V core.

### DIFF
--- a/src/Emulator/Cores/RiscV/IbexRiscV32.cs
+++ b/src/Emulator/Cores/RiscV/IbexRiscV32.cs
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2010-2021 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Peripherals.Timers;
+using Endianess = ELFSharp.ELF.Endianess;
+
+namespace Antmicro.Renode.Peripherals.CPU
+{
+    public partial class IbexRiscV32 : RiscV32
+    {
+        public IbexRiscV32(Machine machine, IRiscVTimeProvider timeProvider = null, uint hartId = 0, PrivilegeArchitecture privilegeArchitecture = PrivilegeArchitecture.Priv1_11, Endianess endianness = Endianess.LittleEndian, string cpuType = "rv32imcu") : base(timeProvider, cpuType, machine, hartId, privilegeArchitecture, endianness, interruptMode: InterruptMode.Vectored)
+        {
+        }
+    }
+}

--- a/src/Emulator/Cores/cores-riscv.csproj
+++ b/src/Emulator/Cores/cores-riscv.csproj
@@ -49,6 +49,7 @@
     <Compile Include="RiscV\BaseRiscV.cs" />
     <Compile Include="RiscV\PlatformLevelInterruptController.cs" />
     <Compile Include="RiscV\PrivilegeLevel.cs" />
+    <Compile Include="RiscV\IbexRiscV32.cs" />
     <Compile Include="RiscV\Minerva.cs" />
     <Compile Include="RiscV\Ri5cy.cs" />
     <Compile Include="RiscV\SimpleCSR.cs" />


### PR DESCRIPTION
This is in reference to: https://github.com/renode/renode-infrastructure/pull/33
This uses sets vectored interrupts.