### PR TITLE
Fix 64 bit address and size generation in mpfs pdma model

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/DMA/MPFS_PDMA.cs
+++ b/src/Emulator/Peripherals/Peripherals/DMA/MPFS_PDMA.cs
@@ -256,9 +256,17 @@ namespace Antmicro.Renode.Peripherals.DMA
                 execDestinationLow.Write(0, nextDestinationLow.Value);
                 execDestinationHigh.Write(0, nextDestinationHigh.Value);
 
-                ulong sourceAddress = (nextSourceHigh.Value << 32) | nextSourceLow.Value;
-                ulong destinationAddress = (nextDestinationHigh.Value << 32) | nextDestinationLow.Value;
-                ulong size = (nextBytesHigh.Value << 32) | nextBytesLow.Value;
+                ulong sourceAddress = nextSourceHigh.Value;
+                sourceAddress = sourceAddress << 32;
+                sourceAddress = sourceAddress + nextSourceLow.Value;
+
+                ulong destinationAddress = nextDestinationHigh.Value;
+                destinationAddress = destinationAddress << 32;
+                destinationAddress = destinationAddress + nextDestinationLow.Value;
+
+                ulong size = nextBytesHigh.Value;
+                size = size << 32;
+                size = size + nextBytesLow.Value;
 
                 parent.machine.LocalTimeSource.ExecuteInNearestSyncedState(_ =>
                 {


### PR DESCRIPTION
Updated the address and size generation of the MPFS PDMA model to allow for 64 bit value generation. Currently the high bits aren't being shifted properly and it results in a 32 bit value as a result.

![source_address_comparison](https://user-images.githubusercontent.com/44862881/127679973-337a582b-e6f6-4b86-b7c7-aba179609af9.png)
. 