### PR TITLE
Simulate BLE connection between central and peripheral zephyr samples

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
+++ b/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
@@ -52,6 +52,8 @@ namespace Antmicro.Renode.Peripherals.Wireless
 
             frame = frame.Skip(4).ToArray();
 
+            this.Log(LogLevel.Noisy, "ReceiveFrame {0}", Misc.PrettyPrintCollectionHex(frame));
+
             var dataAddress = packetPointer.Value;
             machine.SystemBus.WriteBytes(frame, dataAddress);
 

--- a/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
+++ b/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
@@ -177,6 +177,7 @@ namespace Antmicro.Renode.Peripherals.Wireless
             DefineEvent(Registers.AddressSentOrReceived, () => this.Log(LogLevel.Error, "Trying to trigger ADDRESS event, not supported"), Events.Address, "EVENTS_ADDRESS");
             DefineEvent(Registers.PayloadSentOrReceived, () => this.Log(LogLevel.Error, "Trying to trigger PAYLOAD event, not supported"), Events.Payload, "EVENTS_PAYLOAD");
             DefineEvent(Registers.PacketSentOrReceived, () => this.Log(LogLevel.Error, "Trying to trigger END event, not supported"), Events.End, "EVENTS_END");
+            DefineEvent(Registers.CRCOk, () => this.Log(LogLevel.Error, "Trying to trigger CRCOk event, not supported"), Events.CRCOk, "EVENTS_CRCOK");
 
             DefineEvent(Registers.RadioDisabled, Disable, Events.Disabled, "EVENTS_DISABLED");
 
@@ -512,6 +513,7 @@ namespace Antmicro.Renode.Peripherals.Wireless
            timeSource.ExecuteInSyncedState((_) => {
               SetEvent(Events.Payload);
               SetEvent(Events.End);
+              SetEvent(Events.CRCOk);
            }, endTimeStamp);
 
            // BLE stacks use disabled event as common processing trigger. On transmit,

--- a/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
+++ b/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
@@ -51,12 +51,16 @@ namespace Antmicro.Renode.Peripherals.Wireless
                 return;
             }
 
-            frame = frame.Skip(4).ToArray();
+            var addressLength = (int)baseAddressLength.Value + 1;
+            var headerLengthInAir = HeaderLengthInAir();
+            var headerLengthInRAM = HeaderLengthInRAM();
 
             this.Log(LogLevel.Noisy, "ReceiveFrame {0}", Misc.PrettyPrintCollectionHex(frame));
 
             var dataAddress = packetPointer.Value;
-            machine.SystemBus.WriteBytes(frame, dataAddress);
+            machine.SystemBus.WriteBytes(frame, dataAddress, addressLength, headerLengthInAir);
+            var payloadLength = Math.Min(frame[addressLength + s0Length.Value], maxPacketLength.Value);
+            machine.SystemBus.WriteBytes(frame, (ulong)(dataAddress + headerLengthInRAM), addressLength + headerLengthInAir, payloadLength);
 
             machine.LocalTimeSource.ExecuteInNearestSyncedState((_) => {
                SetEvent(Events.Address);
@@ -441,20 +445,30 @@ namespace Antmicro.Renode.Peripherals.Wireless
             }
         }
 
+        private int HeaderLengthInAir()
+        {
+           return (int)Math.Ceiling((s0Length.Value * 8 + lengthFieldLength.Value + s1Length.Value) / 8.0);
+        }
+
+        private int HeaderLengthInRAM()
+        {
+           int ret = (int)s0Length.Value + (int)Math.Ceiling(lengthFieldLength.Value / 8.0) + (int)Math.Ceiling(s1Length.Value / 8.0);
+           if(s1Length.Value == 0 && s1Include.Value)
+           {
+              ret += 1;
+           }
+           return ret;
+        }
+
         private void SendPacket()
         {
             var dataAddress = packetPointer.Value;
-            var headerLength = (int)Math.Ceiling((s0Length.Value * 8 + lengthFieldLength.Value + s1Length.Value) / 8.0);
+            var headerLengthInAir = HeaderLengthInAir();
             var addressLength = (int)baseAddressLength.Value + 1;
-            if(s1Length.Value == 0 && s1Include.Value)
+            var headerLengthInRAM = HeaderLengthInRAM();
+            if(headerLengthInAir != headerLengthInRAM)
             {
-                // based on https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.nrf52832.ps.v1.1/radio.html?cp=4_2_0_22_0#concept_dxt_xfj_4r
-                headerLength++;
-            }
-            var headerLengthInRAM = (int)s0Length.Value + (int)Math.Ceiling(lengthFieldLength.Value / 8.0) + (int)Math.Ceiling(s1Length.Value / 8.0);
-            if(headerLength != headerLengthInRAM)
-            {
-                this.Log(LogLevel.Error, "Length mismatch {0} vs {1}, but continuing anyway", headerLength, headerLengthInRAM);
+                this.Log(LogLevel.Info, "Header length difference between onAir={0} and inRam={1}", headerLengthInAir, headerLengthInRAM);
             }
 
             var data = new byte[addressLength + headerLengthInRAM + maxPacketLength.Value];
@@ -468,7 +482,7 @@ namespace Antmicro.Renode.Peripherals.Wireless
                 this.Log(LogLevel.Error, "Payload length ({0}) longer than the max packet length ({1}), trimming...", payloadLength, maxPacketLength.Value);
                 payloadLength = (byte)maxPacketLength.Value;
             }
-            machine.SystemBus.ReadBytes((ulong)(dataAddress + headerLengthInRAM), payloadLength, data, addressLength + headerLength);
+            machine.SystemBus.ReadBytes((ulong)(dataAddress + headerLengthInRAM), payloadLength, data, addressLength + headerLengthInAir);
             this.Log(LogLevel.Noisy, "Data: {0} Maxlen {1} statlen {2}", Misc.PrettyPrintCollectionHex(data), maxPacketLength.Value, staticLength.Value);
 
             FrameSent?.Invoke(this, data);

--- a/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
+++ b/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
@@ -362,7 +362,8 @@ namespace Antmicro.Renode.Peripherals.Wireless
             }
             else if(radioState == State.RxIdle)
             {
-                while(rxBuffer.TryDequeue(out var packet))
+                // Can only receive one packet per enable
+                if (rxBuffer.TryDequeue(out var packet))
                 {
                     ReceiveFrame(packet);
                 }

--- a/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
+++ b/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
@@ -6,6 +6,7 @@
 //
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Antmicro.Renode.Core;
 using Antmicro.Renode.Core.Structure.Registers;
 using Antmicro.Renode.Logging;
@@ -48,6 +49,8 @@ namespace Antmicro.Renode.Peripherals.Wireless
                 rxBuffer.Enqueue(frame);
                 return;
             }
+
+            frame = frame.Skip(4).ToArray();
 
             var dataAddress = packetPointer.Value;
             machine.SystemBus.WriteBytes(frame, dataAddress);

--- a/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
+++ b/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
@@ -526,6 +526,15 @@ namespace Antmicro.Renode.Peripherals.Wireless
               SetEvent(Events.RSSIEnd);
            }
 
+           // @todo  Fixed PPI channel triggers Timer0 capture. PPI events are
+           //        scheduled through a sync delay, but on hardware that delay
+           //        is sub-microsecond, which is important for timer capture
+           //        behavior in RIOT stack. However, this hard-coding here
+           //        will yield a double capture that might cause incorrect
+           //        behavior. And removing sync delay from PPI implementation
+           //        didn't seem to result in correct behavior.
+           machine.SystemBus.WriteDoubleWord(0x40008044, 0x1);
+
            // Schedule a single bit-counter compare event. This is sufficient
            // for BLE with RIOT stack, however it is possible to use bit
            // counter to generate successive events, which this model will not
@@ -542,6 +551,8 @@ namespace Antmicro.Renode.Peripherals.Wireless
               SetEvent(Events.Payload);
               SetEvent(Events.End);
               SetEvent(Events.CRCOk);
+              // @todo Fixed PPI event for Timer0 capture needs to be fast
+              machine.SystemBus.WriteDoubleWord(0x40008048, 0x1);
            }, endTimeStamp);
 
            // BLE stacks use disabled event as common processing trigger. On transmit,

--- a/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
+++ b/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
@@ -6,6 +6,7 @@
 //
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using Antmicro.Renode.Core;
 using Antmicro.Renode.Core.Structure.Registers;
@@ -70,15 +71,74 @@ namespace Antmicro.Renode.Peripherals.Wireless
             });
         }
 
+        private uint GetCurrentFrequencyMHz()
+        {
+           return (uint)(((frequencyMap.Value) ? 2360 : 2400) + frequency.Value);
+        }
+
+
+        readonly Dictionary<uint, uint> bluetoothLEChannelMap = new Dictionary<uint, uint>() {
+           { 2402, 37 },
+           { 2404, 0 },
+           { 2406, 1 },
+           { 2408, 2 },
+           { 2410, 3 },
+           { 2412, 4 },
+           { 2414, 5 },
+           { 2416, 6 },
+           { 2418, 7 },
+           { 2420, 8 },
+           { 2422, 9 },
+           { 2424, 10 },
+           { 2426, 38 },
+           { 2428, 11 },
+           { 2430, 12 },
+           { 2432, 13 },
+           { 2434, 14 },
+           { 2436, 15 },
+           { 2438, 16 },
+           { 2440, 17 },
+           { 2442, 18 },
+           { 2444, 19 },
+           { 2446, 20 },
+           { 2448, 21 },
+           { 2450, 22 },
+           { 2452, 23 },
+           { 2454, 24 },
+           { 2456, 25 },
+           { 2458, 26 },
+           { 2460, 27 },
+           { 2462, 28 },
+           { 2464, 29 },
+           { 2466, 30 },
+           { 2468, 31 },
+           { 2470, 32 },
+           { 2472, 33 },
+           { 2474, 34 },
+           { 2476, 35 },
+           { 2478, 36 },
+           { 2480, 39 },
+        };
+
+        private int GetBluetoothLEChannel()
+        {
+           var mhz = GetCurrentFrequencyMHz();
+           if (bluetoothLEChannelMap.ContainsKey(mhz))
+           {
+              return (int)bluetoothLEChannelMap[mhz];
+           }
+           return -1;
+        }
+
         public event Action<IRadio, byte[]> FrameSent;
 
         public event Action<uint> EventTriggered;
 
-        public int Channel { get; set; }
+        public int Channel { get => GetBluetoothLEChannel(); set { } }
 
         public long Size => 0x1000;
 
-        public uint Frequency => 2400 + frequency.Value;
+        public uint Frequency => GetCurrentFrequencyMHz();
 
         public GPIO IRQ { get; }
 
@@ -170,7 +230,7 @@ namespace Antmicro.Renode.Peripherals.Wireless
             Registers.Frequency.Define(this, name: "FREQUENCY")
                 .WithValueField(0, 7, out frequency, name: "FREQUENCY")
                 .WithReservedBits(7, 1)
-                .WithTaggedFlag("MAP", 8)
+                .WithFlag(8, out frequencyMap, name: "MAP")
                 .WithReservedBits(9, 23)
             ;
 
@@ -465,6 +525,7 @@ namespace Antmicro.Renode.Peripherals.Wireless
         private IFlagRegisterField[] events;
         private IValueRegisterField packetPointer;
         private IValueRegisterField frequency;
+        private IFlagRegisterField frequencyMap;
         private IValueRegisterField lengthFieldLength;
         private IValueRegisterField s0Length;
         private IValueRegisterField s1Length;

--- a/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
+++ b/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
@@ -20,7 +20,7 @@ namespace Antmicro.Renode.Peripherals.Wireless
         public NRF52840_Radio(Machine machine) : base(machine)
         {
             IRQ = new GPIO();
-            interruptManager = new InterruptManager<Events>(this, IRQ);
+            interruptManager = new InterruptManager<Events>(this, IRQ, "RadioIrq");
             shorts = new Shorts();
             events = new IFlagRegisterField[(int)Events.PHYEnd + 1];
             rxBuffer = new Queue<byte[]>();

--- a/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
+++ b/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
@@ -5,7 +5,7 @@
 // Full license text is available in 'licenses/MIT.txt'.
 //
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using Antmicro.Renode.Core;
 using Antmicro.Renode.Core.Structure.Registers;
@@ -23,7 +23,7 @@ namespace Antmicro.Renode.Peripherals.Wireless
             interruptManager = new InterruptManager<Events>(this, IRQ, "RadioIrq");
             shorts = new Shorts();
             events = new IFlagRegisterField[(int)Events.PHYEnd + 1];
-            rxBuffer = new Queue<byte[]>();
+            rxBuffer = new ConcurrentQueue<byte[]>();
             DefineRegisters();
             Reset();
         }
@@ -34,7 +34,7 @@ namespace Antmicro.Renode.Peripherals.Wireless
             interruptManager.Reset();
             base.Reset();
             addressPrefixes = new byte[8];
-            rxBuffer.Clear();
+            while (rxBuffer.TryDequeue(out var _)) { }
         }
 
         public void FakePacket()
@@ -437,7 +437,7 @@ namespace Antmicro.Renode.Peripherals.Wireless
             data[startIndex + i] = addressPrefixes[logicalAddress];
         }
 
-        private readonly Queue<byte[]> rxBuffer;
+        private readonly ConcurrentQueue<byte[]> rxBuffer;
         private Shorts shorts;
         private byte[] addressPrefixes;
         private State radioState;

--- a/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
+++ b/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
@@ -160,6 +160,9 @@ namespace Antmicro.Renode.Peripherals.Wireless
             RegistersCollection.AddRegister((long)Registers.InterruptDisable,
                 interruptManager.GetInterruptEnableClearRegister<DoubleWordRegister>());
 
+            Registers.CRCStatus.Define(this)
+               .WithFlag(0, valueProviderCallback: (_) => true);
+
             Registers.PacketPointer.Define(this)
                 .WithValueField(0, 32, out packetPointer, name: "PACKETPTR")
             ;

--- a/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
+++ b/src/Emulator/Peripherals/Peripherals/Wireless/NRF52840_Radio.cs
@@ -57,13 +57,17 @@ namespace Antmicro.Renode.Peripherals.Wireless
             var dataAddress = packetPointer.Value;
             machine.SystemBus.WriteBytes(frame, dataAddress);
 
-            SetEvent(Events.Address);
-            SetEvent(Events.Payload);
-            SetEvent(Events.End);
-            if(shorts.EndDisable.Value)
-            {
-                Disable();
-            }
+            machine.LocalTimeSource.ExecuteInNearestSyncedState((_) => {
+               SetEvent(Events.Address);
+               SetEvent(Events.Payload);
+               SetEvent(Events.End);
+               machine.LocalTimeSource.ExecuteInNearestSyncedState((__) => {
+                  if(shorts.EndDisable.Value)
+                  {
+                      Disable();
+                  }
+               });
+            });
         }
 
         public event Action<IRadio, byte[]> FrameSent;


### PR DESCRIPTION
Changes to enable simulation of bluetooth connection between zephyr samples central_hr and periperhal_hr. I've been testing against main, [most recently this commit](https://github.com/zephyrproject-rtos/zephyr/commit/d6adbf9d0e0036b6d7f6e5760d439e864ed289af). Simulation should work without any modifications to project configs. I did most development with heart-rate samples, but also did a quick check with central_ht/peripheral_ht and those seemed to connect.

west commands to build zephyr images
```
west build -d ../build-central-hr -b nrf52840dk_nrf52840 -p always samples/bluetooth/central_hr
west build -d ../build-peripheral-hr -b nrf52840dk_nrf52840 -p always samples/bluetooth/peripheral_hr
```

Changes here are paired with updates to parent renode repository, which contains an example script for executing the demo. See [bluetooth-work branch in my fork](https://github.com/grifcj/renode/commits/bluetooth-work).

The changes primarily deal with updates for coordinating the radio with timers and PPI. The zephyr stack makes heavy use of PPI and rtc0, timer0, & timer1 for scheduling actions in bluetooth controller firmware. The firmware is fairly time aware, and expects radio actions to consume some amount of time and that simulation has enough resolution to adequately order events below 100 us. I found that a simulation quantum of 100 us would not function, but a 10 us one does. Perhaps there are ways around this, as it unfortunately affects overall simulation performance.

I've only tested with stock zephyr configuration of samples and with privacy and security disabled. Things that rely on additional hardware features beyond default config, e.g. TIFS hardware support, isn't included in these changes.

![image](https://user-images.githubusercontent.com/13724578/138049433-32a56709-51c2-485a-8a68-0f8ce7729c26.png)

![image](https://user-images.githubusercontent.com/13724578/138049098-8cc1ee63-ab24-4bf6-af88-5ba4535683de.png)