### PR TITLE
userinterface: use correct machine during reset

### DIFF
--- a/src/Emulator/Extensions/UserInterface/Monitor.cs
+++ b/src/Emulator/Extensions/UserInterface/Monitor.cs
@@ -261,23 +261,23 @@ namespace Antmicro.Renode.UserInterface
             string machineName;
             if(EmulationManager.Instance.CurrentEmulation.TryGetMachineName(machine, out machineName))
             {
+                var activeMachine = _currentMachine;
+                _currentMachine = machine;
                 var macroName = GetVariableName("reset");
                 Token resetMacro;
                 if(macros.TryGetValue(macroName, out resetMacro))
                 {
-                    var activeMachine = _currentMachine;
-                    _currentMachine = machine;
                     var macroLines = resetMacro.GetObjectValue().ToString().Split('\n');
                     foreach(var line in macroLines)
                     {
                         Parse(line, Interaction);
                     }
-                    _currentMachine = activeMachine;
                 }
                 else
                 {
                     Logger.LogAs(this, LogLevel.Warning, "No action for reset - macro {0} is not registered.", macroName);
                 }
+                _currentMachine = activeMachine;
             }
         }
 


### PR DESCRIPTION
When a peripheral requests a reset (such as by calling
`machine.RequestReset()`, a machine is supposed to reset.

From the console, `machine Reset` may only be run when a machine has
been set using `mach set`, and as a result that machine's variables are
in scope.

One very important variable is `$reset`, which contains the script to
run when a machine is reset.

When `machine Reset` is run from the monitor, this variable is in scope.
However, when run from a peripheral this variable may not be in scope
unless the user has already `set` the correct machine. Worse, if the
user calls `set` on the wrong machine then the wrong machine will have
its `$reset` script called.

Move the code that sets the current machine so that it wraps the
entirety of the `ResetMachine(Machine)` call. This ensures that the
`$reset` variable is in-scope for the entire call, rather than only when
lines are executed.

Signed-off-by: Sean Cross <sean@xobs.io>