### PR TITLE
[GH#332] peripherals: stm32_adc: fix end-of-conversion interrupt logic

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Analog/STM32_ADC.cs
+++ b/src/Emulator/Peripherals/Peripherals/Analog/STM32_ADC.cs
@@ -267,8 +267,8 @@ namespace Antmicro.Renode.Peripherals.Analog
          var scanModeActive = scanMode.Value && currentChannelIdx < regularSequenceLen - 1;
          var scanModeFinished = scanMode.Value && currentChannelIdx == regularSequenceLen - 1;
 
-         // Signal EOC if EOCS set or we finished scanning regular group
-         endOfConversion.Value = endOfConversionSelect.Value || scanModeFinished;
+         // Signal EOC if EOCS set with scan mode enabled and finished or we finished scanning regular group
+         endOfConversion.Value = scanModeActive ? (endOfConversionSelect.Value || scanModeFinished) : true;
 
          // Iterate to next channel
          currentChannelIdx = (currentChannelIdx + 1) % regularSequenceLen;


### PR DESCRIPTION
end-of-conversion interrupt should be triggered if a sequence conversion
is finished and EOCS=1 or if a normal conversion is finished, regardless
of EOCS value.

Fixes renode/renode#332
