### PR TITLE
Add socket implementation with I2c protocol 

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Mocks/HPSHostController.cs
+++ b/src/Emulator/Peripherals/Peripherals/Mocks/HPSHostController.cs
@@ -181,10 +181,9 @@ namespace Antmicro.Renode.Extensions.Mocks
         }
 
         // Register 6:
-        public string[,] ReadError(TimeInterval timeInterval)
-        {
-            IssueCommand(new byte[] { ((byte)Commands.RegisterAccess << 6) | (byte)RegisterAccessType.Error });
-            return FormatCommonErrorStatus(GetBytesFromSlave(2, timeInterval));
+        public string[,] ReadError(TimeInterval timeInterval) 
+        { 
+            return FormatCommonErrorStatus(ReadErrorBytes(timeInterval)); 
         }
 
         public byte[] ReadErrorBytes(TimeInterval timeInterval)
@@ -469,10 +468,6 @@ namespace Antmicro.Renode.Extensions.Mocks
                         break;
                 }
             }
-            if (prevWrite) 
-            {
-                currentSlave.Read(0);
-            }
         }
 
         private int GetLength(Socket connection){
@@ -508,9 +503,7 @@ namespace Antmicro.Renode.Extensions.Mocks
 
         private bool SocketConnected(Socket s)
         {
-            bool dataAvailableForReading = s.Poll(1000, SelectMode.SelectRead);
-            bool availableBytesIsEmpty = (s.Available == 0);
-            return !(dataAvailableForReading && availableBytesIsEmpty);
+            return !(s.Poll(100, SelectMode.SelectRead) && s.Available == 0);
         }
  
         private string[,] FormatSystemStatus(byte[] data)

--- a/src/Emulator/Peripherals/Peripherals/Mocks/HPSHostController.cs
+++ b/src/Emulator/Peripherals/Peripherals/Mocks/HPSHostController.cs
@@ -503,7 +503,9 @@ namespace Antmicro.Renode.Extensions.Mocks
 
         private bool SocketConnected(Socket s)
         {
-            return !(s.Poll(100, SelectMode.SelectRead) && s.Available == 0);
+            bool dataAvailableForReading = s.Poll(1000, SelectMode.SelectRead);
+            bool availableBytesIsEmpty = (s.Available == 0);
+            return !(dataAvailableForReading && availableBytesIsEmpty);
         }
  
         private string[,] FormatSystemStatus(byte[] data)

--- a/src/Emulator/Peripherals/Peripherals/Mocks/HPSHostController.cs
+++ b/src/Emulator/Peripherals/Peripherals/Mocks/HPSHostController.cs
@@ -344,7 +344,7 @@ namespace Antmicro.Renode.Extensions.Mocks
         // returns true when the buffer is empty.
         private bool RXNECleared()
         {
-            return currentSlave.RxNotEmpty;
+            return !currentSlave.RxNotEmpty;
         }
         
         private void PollForRegisterBit(RegisterBitName bitName){
@@ -642,7 +642,6 @@ namespace Antmicro.Renode.Extensions.Mocks
             table.AddRow((data[1] & 0x1) == 1 ? "1" : "0", "0", "ROTATION", "Rotation bit 0");
             return table.ToArray();
         }
-
 
         private STM32F7_I2C currentSlave;
 


### PR DESCRIPTION
Using socket communication to simulate actual i2c communication so that we can use hps toolings written to run tests on flashed Renode firmware.