### PR TITLE
[#343]: Incorrect handling of the GPIOx_BRR register for STM32_GPIO

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/STM32_GPIOPort.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/STM32_GPIOPort.cs
@@ -177,7 +177,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 },
                 {(long)Registers.BitReset, new DoubleWordRegister(this)
                     .WithValueField(0, 16, FieldMode.Write, 
-                        writeCallback: (_, val) => { if(val != 0) WriteState((ushort)(BitHelper.GetValueFromBitsArray(State) ^ val)); },
+                        writeCallback: (_, val) => { if(val != 0) WriteState((ushort)(BitHelper.GetValueFromBitsArray(State) & ~val)); },
                         name: "GPIOx_BRR")
                     .WithReservedBits(16, 16)
                 },


### PR DESCRIPTION
fixes https://github.com/renode/renode/issues/343