### PR TITLE
Update OpenTitan flash controller register definitions

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/MTD/OpenTitan_FlashController.cs
+++ b/src/Emulator/Peripherals/Peripherals/MTD/OpenTitan_FlashController.cs
@@ -247,14 +247,31 @@ namespace Antmicro.Renode.Peripherals.MTD
                 .WithReservedBits(5, 27);
 
             Registers.ErrorCode.Define(this)
-                .WithFlag(0, out outOfBoundsError, FieldMode.Read | FieldMode.WriteOneToClear, name: "oob_err")
+                .WithFlag(0, out outOfBoundsError, FieldMode.Read | FieldMode.WriteOneToClear, name: "op_err")
                 .WithFlag(1, out memoryProtectionError, FieldMode.Read | FieldMode.WriteOneToClear, name: "mp_err")
                 .WithTaggedFlag("rd_err", 2)
-                .WithTaggedFlag("prog_win_err", 3)
-                .WithTaggedFlag("prog_type_err", 4)
-                .WithTaggedFlag("flash_phy_err", 5)
-                .WithTaggedFlag("update_err", 6)
-                .WithReservedBits(7, 25);
+                .WithTaggedFlag("prog_err", 3)
+                .WithTaggedFlag("prog_win_err", 4)
+                .WithTaggedFlag("prog_type_err", 5)
+                .WithTaggedFlag("flash_macro", 6)
+                .WithTaggedFlag("update_err", 7)
+                .WithReservedBits(8, 24);
+
+            Registers.FaultStatus.Define(this)
+                .WithFlag(0, out outOfBoundsError, FieldMode.Read | FieldMode.WriteOneToClear, name: "op_err")
+                .WithFlag(1, out memoryProtectionError, FieldMode.Read | FieldMode.WriteOneToClear, name: "mp_err")
+                .WithTaggedFlag("rd_err", 2)
+                .WithTaggedFlag("prog_err", 3)
+                .WithTaggedFlag("prog_win_err", 4)
+                .WithTaggedFlag("prog_type_err", 5)
+                .WithTaggedFlag("flash_macro_err", 6)
+                .WithTaggedFlag("seed_err", 7)
+                .WithTaggedFlag("phy_relbl_err", 8)
+                .WithTaggedFlag("phy_storage_err", 9)
+                .WithTaggedFlag("spurious_ack", 10)
+                .WithTaggedFlag("arb_err", 11)
+                .WithTaggedFlag("host_gnt_err", 12)
+                .WithReservedBits(13, 19);
 
             Registers.ErrorAddress.Define(this)
                 .WithValueField(0, 32, out errorAddress, FieldMode.Read, name: "ERR_ADDR");


### PR DESCRIPTION
Add missing fault status definition to avoid unit test warning message spamming.