### PR TITLE
[FIX] FilePath: Fix the file share type

### DIFF
--- a/src/Emulator/Main/Utilities/FilePath.cs
+++ b/src/Emulator/Main/Utilities/FilePath.cs
@@ -35,7 +35,7 @@ namespace Antmicro.Renode.Utilities
 
             try
             {
-                using(var fs = File.Open(path, FileMode.Open, fileAccess))
+                using(var fs = File.Open(path, FileMode.Open, fileAccess, FileShare.ReadWrite))
                 {
                     if(!fs.CanRead && fileAccess == FileAccess.Read)
                     {


### PR DESCRIPTION
FilePath opens the file with no sharing while validating the file permission.
https://learn.microsoft.com/en-us/dotnet/api/system.io.file.open?view=net-7.0#system-io-file-open(system-string-system-io-filemode-system-io-fileaccess)

This behavior will cause failure when 2 Renode instances load the same elf file simultaneously.  The one loads first will open the file with FileShare.Read.  The second one will fail to validate the file because it tries to open the file with FileShare.None, but the file has been opened with FileShare.Read.  To fix this issue, we let FilePath open the file with the least restricted file share type FileShare.ReadWrite when validating the file permission.