### PR TITLE
[FIX] Opentitan_SpiHost: Fix TXQD/RXQD/CMDQD

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/SPI/OpenTitan_SpiHost.cs
+++ b/src/Emulator/Peripherals/Peripherals/SPI/OpenTitan_SpiHost.cs
@@ -53,6 +53,7 @@ namespace Antmicro.Renode.Peripherals.SPI
             if(addr == (long)Registers.Txdata)
             {
                 EnqueueTx(val, sizeof(uint));
+                return;
             }
             RegistersCollection.Write(addr, val);
         }
@@ -68,6 +69,7 @@ namespace Antmicro.Renode.Peripherals.SPI
             if(addr == (long)Registers.Txdata)
             {
                 EnqueueTx(val, sizeof(ushort));
+                return;
             }
             RegistersCollection.Write(addr, val);
         }
@@ -77,6 +79,7 @@ namespace Antmicro.Renode.Peripherals.SPI
             if(addr == (long)Registers.Txdata)
             {
                 EnqueueTx(val, sizeof(byte));
+                return;
             }
             RegistersCollection.Write(addr, val);
         }
@@ -139,9 +142,9 @@ namespace Antmicro.Renode.Peripherals.SPI
                 })
             },
             {(long)Registers.Status, new DoubleWordRegister(this)
-                .WithValueField(0, 8, FieldMode.Read, valueProviderCallback: _ => txCountInWords, name: "TXQD")
-                .WithValueField(8, 8, FieldMode.Read, valueProviderCallback: _ => rxCountInWords, name: "RXQD")
-                .WithValueField(16, 4, FieldMode.Read, valueProviderCallback: _ => cmdCountInWords, name: "CMDQD")
+                .WithValueField(0, 8, FieldMode.Read, valueProviderCallback: _ => txCountInDoubleWords, name: "TXQD")
+                .WithValueField(8, 8, FieldMode.Read, valueProviderCallback: _ => rxCountInDoubleWords, name: "RXQD")
+                .WithValueField(16, 4, FieldMode.Read, valueProviderCallback: _ => cmdCountInDoubleWords, name: "CMDQD")
                 .WithFlag(20, out rxWatermarkEventTriggered, FieldMode.Read, name: "RXWM")
                 .WithReservedBits(21, 1)
                 .WithTaggedFlag("BYTEORDER", 22)


### PR DESCRIPTION
- The TXQD/RXQD/CMDQD fields in the STATUS register were returning the count of 16-bit values in the FIFO, but should return the count of 32-bit values (see: https://opentitan.org/book/hw/ip/spi_host/doc/registers.html#status--cmdqd)
- Additionally, return early in WriteByte/WriteWord/WriteDoubleWord to squelch a lot of warning noise.