### PR TITLE
526-MiV_CoreGPIO Adding Readback for OUTBUFF

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/MiV_CoreGPIO.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/MiV_CoreGPIO.cs
@@ -116,7 +116,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                                 this.Log(LogLevel.Warning, "Cannot change pin #{0} direction because it is fixed");
                                 return;
                             }
-                            
+
                             if(value)
                             {
                                 irqManager.PinDirection[j] |= GPIOInterruptManager.Direction.Input;

--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/MiV_CoreGPIO.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/MiV_CoreGPIO.cs
@@ -130,7 +130,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                         {
                             return (irqManager.PinDirection[j] & GPIOInterruptManager.Direction.Input) != 0;
                         }, name: "INREG")
-                    .WithTag("OUTBUFF", 2, 1)
+                    .WithFlag(2, name: "OUTBUFF") // The register only provides a read-back function
                     .WithFlag(3, writeCallback: (_, v) => irqManager.InterruptEnable[j] = v, valueProviderCallback: _ => irqManager.InterruptEnable[j], name: "INTENABLE")
                     .WithReservedBits(4, 1)
                     .WithValueField(5, 3, writeCallback: (_, value) =>


### PR DESCRIPTION
In order to run tests using the MiV_CoreGPIO peripheral it is required that the OUTBUFF tag has both read and write functionality. Currently if only has the write functionality as is using a tag. In order to allow for both read and write functionality it is necessary to change this tag to a flag.