### PR TITLE
528-MiV_CoreTimer Added Reload for OneShot Mode

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Timers/MiV_CoreTimer.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/MiV_CoreTimer.cs
@@ -1,5 +1,5 @@
 ﻿//
-// Copyright (c) 2010-2018 Antmicro
+// Copyright (c) 2010-2023 Antmicro
 //
 // This file is licensed under the MIT License.
 // Full license text is available in 'licenses/MIT.txt'.
@@ -26,7 +26,18 @@ namespace Antmicro.Renode.Peripherals.Timers
             var registersMap = new Dictionary<long, DoubleWordRegister>
             {
                 {(long)Registers.Load, new DoubleWordRegister(this)
-                    .WithValueField(0, 32, writeCallback: (_, val) => Limit = val, valueProviderCallback: _ => checked((uint)Limit), name: "LoadValue")},
+                    .WithValueField(0, 32, name: "LoadValue",
+                        writeCallback: (_, val) =>
+                            {
+                                Limit = val;
+                                if(Mode == WorkMode.OneShot)
+                                {
+                                    Enabled = true;
+                                }
+                            },
+                        valueProviderCallback: (_) => checked((uint)Limit)
+                    )
+                },
 
                 {(long)Registers.Value, new DoubleWordRegister(this, 0xFFFFFFFF)
                     .WithValueField(0, 32, FieldMode.Read, valueProviderCallback: _ => checked((uint)Value), name: "CurrentValue")},


### PR DESCRIPTION
MiV_CoreTimer has two modes One-shot and Continuous. When operating in One-shot mode the timer should count down from its initial value and stop. When given an initial value it should reload meaning it should restart counting down from the given number. Currently it will not start counting down for a second time after being set with an initial value.