### PR TITLE
539 - BugFix Level-Triggered Interrupts Behaviour

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/MPFS_GPIO.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/MPFS_GPIO.cs
@@ -167,6 +167,12 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 }
                 base.OnGPIO(number, value);
                 irqManager.RefreshInterrupts();
+                                
+                if( ((false == value) && (GPIOInterruptManager.InterruptTrigger.ActiveHigh == irqManager.InterruptType[number])) ||
+                    ((true == value) && (GPIOInterruptManager.InterruptTrigger.ActiveLow == irqManager.InterruptType[number])) )
+                {
+                    irqManager.ClearInterrupt(number);
+                }
 
                 // RefreshInterrupts will update the main IRQ, but it will not update the connection.
                 // We have to do it manually, as connection reflects if there is an active interrupt for the given pin.


### PR DESCRIPTION
Added the functionality for the level-triggered interrupt to de-assert itself after the input causing the interrupt has gone.