### PR TITLE
Set connection status to active for TCP connection

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Network/QuectelModem.cs
+++ b/src/Emulator/Peripherals/Peripherals/Network/QuectelModem.cs
@@ -546,6 +546,11 @@ namespace Antmicro.Renode.Peripherals.Network
                 else
                 {
                     this.Log(LogLevel.Debug, "Connection {0} opened successfully", connectionId);
+					
+					if(serviceType == Tcp)
+					{
+						ExecuteWithDelay(() => SendSignalingConnectionStatus(true), CsconDelay + 50);
+					}
                 }
                 sockets[connectionId] = service;
                 SendString($"+QIOPEN: {connectionId},{(service == null ? 1 : 0)}");

--- a/src/Emulator/Peripherals/Peripherals/Network/QuectelModem.cs
+++ b/src/Emulator/Peripherals/Peripherals/Network/QuectelModem.cs
@@ -547,10 +547,10 @@ namespace Antmicro.Renode.Peripherals.Network
                 {
                     this.Log(LogLevel.Debug, "Connection {0} opened successfully", connectionId);
 					
-					if(serviceType == Tcp)
-					{
-						ExecuteWithDelay(() => SendSignalingConnectionStatus(true), CsconDelay + 50);
-					}
+                    if(serviceType == Tcp)
+                    {
+                        ExecuteWithDelay(() => SendSignalingConnectionStatus(true), CsconDelay + 50);
+                    }
                 }
                 sockets[connectionId] = service;
                 SendString($"+QIOPEN: {connectionId},{(service == null ? 1 : 0)}");


### PR DESCRIPTION
@mateusz-holenko 

When opening a TCP connection the connection status is not set to active, CSCON is still 0. 

Expected behaviour:

![image](https://github.com/renode/renode-infrastructure/assets/130460377/3abf73e8-caa3-4abc-9c00-51c8d7f316ca)

Observed behavior from renode:

![image](https://github.com/renode/renode-infrastructure/assets/130460377/adfc5688-52e6-427e-843a-a891dfe324e7)
