### PR TITLE
Add STM32C0/G0/L0 ADC driver

### DIFF
--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -371,6 +371,7 @@
     <Compile Include="Peripherals\Miscellaneous\LiteX_MMCM.cs" />
     <Compile Include="Peripherals\Analog\EOSS3_ADC.cs" />
     <Compile Include="Peripherals\Analog\STM32_ADC_Common.cs" />
+    <Compile Include="Peripherals\Analog\STM32C0_ADC.cs" />
     <Compile Include="Peripherals\Analog\STM32F0_ADC.cs" />
     <Compile Include="Peripherals\Analog\STM32G0_ADC.cs" />
     <Compile Include="Peripherals\Analog\STM32L0_ADC.cs" />

--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -372,6 +372,7 @@
     <Compile Include="Peripherals\Analog\EOSS3_ADC.cs" />
     <Compile Include="Peripherals\Analog\STM32_ADC_Common.cs" />
     <Compile Include="Peripherals\Analog\STM32F0_ADC.cs" />
+    <Compile Include="Peripherals\Analog\STM32L0_ADC.cs" />
     <Compile Include="Peripherals\Analog\STM32WBA_ADC.cs" />
     <Compile Include="Peripherals\Analog\Xilinx_XADC.cs" />
     <Compile Include="Peripherals\Analog\STM32_ADC.cs" />

--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -372,6 +372,7 @@
     <Compile Include="Peripherals\Analog\EOSS3_ADC.cs" />
     <Compile Include="Peripherals\Analog\STM32_ADC_Common.cs" />
     <Compile Include="Peripherals\Analog\STM32F0_ADC.cs" />
+    <Compile Include="Peripherals\Analog\STM32G0_ADC.cs" />
     <Compile Include="Peripherals\Analog\STM32L0_ADC.cs" />
     <Compile Include="Peripherals\Analog\STM32WBA_ADC.cs" />
     <Compile Include="Peripherals\Analog\Xilinx_XADC.cs" />

--- a/src/Emulator/Peripherals/Peripherals/Analog/STM32C0_ADC.cs
+++ b/src/Emulator/Peripherals/Peripherals/Analog/STM32C0_ADC.cs
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2010-2023 Antmicro
+// Copyright (c) 2023 OS Systems
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Peripherals.DMA;
+
+namespace Antmicro.Renode.Peripherals.Analog
+{
+    public class STM32C0_ADC : STM32_ADC_Common
+    {
+        public STM32C0_ADC(IMachine machine, double referenceVoltage, uint externalEventFrequency, int dmaChannel = 0, IDMA dmaPeripheral = null)
+            : base(
+                machine,
+                referenceVoltage,
+                externalEventFrequency,
+                dmaChannel,
+                dmaPeripheral,
+                // Base class configuration
+                watchdogCount: 3,
+                hasCalibration: true,
+                hasHighCalAddress: false,
+                channelCount: 23,
+                hasPrescaler: false,
+                hasVbatPin: false,
+                hasChannelSequence: true,
+                hasPowerRegister: false
+            )
+        {}
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/Analog/STM32F0_ADC.cs
+++ b/src/Emulator/Peripherals/Peripherals/Analog/STM32F0_ADC.cs
@@ -22,6 +22,7 @@ namespace Antmicro.Renode.Peripherals.Analog
                 // Base class configuration
                 watchdogCount: 1,
                 hasCalibration: false,
+                hasHighCalAddress: false,
                 channelCount: 19,
                 hasPrescaler: false,
                 hasVbatPin: true,

--- a/src/Emulator/Peripherals/Peripherals/Analog/STM32G0_ADC.cs
+++ b/src/Emulator/Peripherals/Peripherals/Analog/STM32G0_ADC.cs
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2010-2023 Antmicro
+// Copyright (c) 2023 OS Systems
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Peripherals.DMA;
+
+namespace Antmicro.Renode.Peripherals.Analog
+{
+    public class STM32G0_ADC : STM32_ADC_Common
+    {
+        public STM32G0_ADC(IMachine machine, double referenceVoltage, uint externalEventFrequency, int dmaChannel = 0, IDMA dmaPeripheral = null)
+            : base(
+                machine,
+                referenceVoltage,
+                externalEventFrequency,
+                dmaChannel,
+                dmaPeripheral,
+                // Base class configuration
+                watchdogCount: 3,
+                hasCalibration: true,
+                hasHighCalAddress: false,
+                channelCount: 19,
+                hasPrescaler: true,
+                hasVbatPin: true,
+                hasChannelSequence: true,
+                hasPowerRegister: false
+            )
+        {}
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/Analog/STM32L0_ADC.cs
+++ b/src/Emulator/Peripherals/Peripherals/Analog/STM32L0_ADC.cs
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2010-2023 Antmicro
+// Copyright (c) 2023 OS Systems
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Peripherals.DMA;
+
+namespace Antmicro.Renode.Peripherals.Analog
+{
+    public class STM32L0_ADC : STM32_ADC_Common
+    {
+        public STM32L0_ADC(IMachine machine, double referenceVoltage, uint externalEventFrequency, int dmaChannel = 0, IDMA dmaPeripheral = null)
+            : base(
+                machine,
+                referenceVoltage,
+                externalEventFrequency,
+                dmaChannel,
+                dmaPeripheral,
+                // Base class configuration
+                watchdogCount: 1,
+                hasCalibration: true,
+                hasHighCalAddress: false,
+                channelCount: 18,
+                hasPrescaler: true,
+                hasVbatPin: false,
+                hasChannelSequence: false,
+                hasPowerRegister: true
+            )
+        {}
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/Analog/STM32WBA_ADC.cs
+++ b/src/Emulator/Peripherals/Peripherals/Analog/STM32WBA_ADC.cs
@@ -22,6 +22,7 @@ namespace Antmicro.Renode.Peripherals.Analog
                 // Base class configuration
                 watchdogCount: 3,
                 hasCalibration: true,
+                hasHighCalAddress: true,
                 channelCount: 14,
                 hasPrescaler: true,
                 hasVbatPin: false,

--- a/src/Emulator/Peripherals/Peripherals/Analog/STM32_ADC_Common.cs
+++ b/src/Emulator/Peripherals/Peripherals/Analog/STM32_ADC_Common.cs
@@ -433,7 +433,7 @@ namespace Antmicro.Renode.Peripherals.Analog
                     }, name: "SCANDIR")
                 .WithEnumField<DoubleWordRegister, Resolution>(this.hasChannelSequence ? 2 : 3, 2, out resolution, name: "RES")
                 .WithEnumField<DoubleWordRegister, Align>(5, 1, out align, name: "ALIGN")
-                .WithTag("EXTSEL", 6, 2)
+                .WithTag("EXTSEL", 6, 3)
                 .WithReservedBits(9, 1)
                 .WithValueField(10, 2, writeCallback: (_, val) =>
                     {

--- a/src/Emulator/Peripherals/Peripherals/Analog/STM32_ADC_Common.cs
+++ b/src/Emulator/Peripherals/Peripherals/Analog/STM32_ADC_Common.cs
@@ -514,7 +514,9 @@ namespace Antmicro.Renode.Peripherals.Analog
                                 sequenceInProgress = false;
                             }
                         }, name: "ADSTP")
-                    .WithReservedBits(5, 25)
+                    .WithReservedBits(5, 22)
+                    .WithTag("ADVREGEN", 28, 1)
+                    .WithReservedBits(29, 2)
                     .WithTaggedFlag("ADCAL", 31)
                 },
                 {(long)Registers.Configuration1, configurationRegister1},

--- a/src/Emulator/Peripherals/Peripherals/Analog/STM32_ADC_Common.cs
+++ b/src/Emulator/Peripherals/Peripherals/Analog/STM32_ADC_Common.cs
@@ -187,7 +187,7 @@ namespace Antmicro.Renode.Peripherals.Analog
             var adcReady = adcReadyFlag.Value && adcReadyInterruptEnable.Value;
             var analogWatchdog = analogWatchdogsInterruptEnable.Zip(analogWatchdogFlags, (enable, flag) =>
             {
-                return enable.Value && flag.Value;  
+                return enable.Value && flag.Value;
             }).Any(flag => flag);
             var endOfSampling = endOfSamplingFlag.Value && endOfSamplingInterruptEnable.Value;
             var endOfConversion = endOfConversionFlag.Value && endOfConversionInterruptEnable.Value;
@@ -331,7 +331,7 @@ namespace Antmicro.Renode.Peripherals.Analog
                 default:
                     throw new Exception("This should never have happend!");
             }
-                
+
             uint referencedValue = (uint)Math.Round((sampleInMilivolts / (referenceVoltage * 1000)) * ((1 << resolutionInBits) - 1));
             if(align.Value == Align.Left)
             {
@@ -399,11 +399,11 @@ namespace Antmicro.Renode.Peripherals.Analog
                 .WithEnumField<DoubleWordRegister, Align>(5, 1, out align, name: "ALIGN")
                 .WithTag("EXTSEL", 6, 2)
                 .WithReservedBits(9, 1)
-                .WithValueField(10, 2, writeCallback: (_, val) => 
-                    { 
+                .WithValueField(10, 2, writeCallback: (_, val) =>
+                    {
                         // On hardware it is possible to configure on which edge should the trigger fire
                         // This Peripheral mocks external trigger using `externalEventFrequency`, so we only distinguish between manual/external trigger
-                        externalTrigger = (val > 0); 
+                        externalTrigger = (val > 0);
                     }, name: "EXTEN")
                 .WithTaggedFlag("OVRMOD", 12)
                 .WithTaggedFlag("CONT", 13)
@@ -481,7 +481,7 @@ namespace Antmicro.Renode.Peripherals.Analog
                             {
                                 enabled = true;
                                 adcReadyFlag.Value = true;
-                                UpdateInterrupts(); 
+                                UpdateInterrupts();
                             }
                         }, name: "ADEN")
                     // Reading one from below field would mean that command is in progress. This is never the case in this model
@@ -587,7 +587,7 @@ namespace Antmicro.Renode.Peripherals.Analog
                     .WithTaggedFlag("DPD", 1) // Deep-power-down mode
                     .WithReservedBits(2, 30));
             }
-            
+
             return registers;
         }
 
@@ -597,11 +597,11 @@ namespace Antmicro.Renode.Peripherals.Analog
         private bool sequenceInProgress;
         private bool awaitingConversion;
         private bool[] channelSelected;
-        
+
         private IEnumRegisterField<Align> align;
         private IEnumRegisterField<Resolution> resolution;
         private IEnumRegisterField<ScanDirection> scanDirection;
-        
+
         private IFlagRegisterField dmaEnabled;
         private IFlagRegisterField analogWatchdogEnable;
         private IFlagRegisterField startFlag;
@@ -620,7 +620,7 @@ namespace Antmicro.Renode.Peripherals.Analog
         private IFlagRegisterField endOfSamplingInterruptEnable;
         private IFlagRegisterField endOfSequenceInterruptEnable;
         private IFlagRegisterField analogWatchdogSingleChannel;
-        
+
         private IValueRegisterField data;
         // Watchdog 1 either watches all channels or a single channel
         private IValueRegisterField analogWatchdogChannel;

--- a/src/Emulator/Peripherals/Peripherals/Analog/STM32_ADC_Common.cs
+++ b/src/Emulator/Peripherals/Peripherals/Analog/STM32_ADC_Common.cs
@@ -357,7 +357,7 @@ namespace Antmicro.Renode.Peripherals.Analog
                             machine.LocalTimeSource.ExecuteInNearestSyncedState((___) => SampleNextChannel());
                         }
                     }, name: "EOC")
-                .WithFlag(3, out endOfSequenceFlag, FieldMode.Read | FieldMode.WriteOneToClear, name: "EOSEQ")
+                .WithFlag(3, out endOfSequenceFlag, FieldMode.Read | FieldMode.WriteOneToClear, name: "EOS")
                 .WithFlag(4, out adcOverrunFlag, FieldMode.Read | FieldMode.WriteOneToClear, name: "OVR")
                 .WithReservedBits(5, 2)
                 .WithFlags(7, WatchdogCount, out analogWatchdogFlags, FieldMode.Read | FieldMode.WriteOneToClear, name: "AWD")

--- a/src/Emulator/Peripherals/Peripherals/Analog/STM32_ADC_Common.cs
+++ b/src/Emulator/Peripherals/Peripherals/Analog/STM32_ADC_Common.cs
@@ -478,7 +478,12 @@ namespace Antmicro.Renode.Peripherals.Analog
             }
 
             var configurationRegister2 = new DoubleWordRegister(this)
-                .WithReservedBits(0, 30)
+                .WithFlag(0, name: "OVSE")
+                .WithReservedBits(1, 1)
+                .WithFlags(2, 3, name: "OVSR")
+                .WithFlags(5, 4, name: "OVSS")
+                .WithTag("TOVS", 9, 1)
+                .WithReservedBits(10, 20)
                 .WithTag("CKMODE", 30, 2);
 
             var commonConfigurationRegister = new DoubleWordRegister(this)

--- a/src/Emulator/Peripherals/Peripherals/Analog/STM32_ADC_Common.cs
+++ b/src/Emulator/Peripherals/Peripherals/Analog/STM32_ADC_Common.cs
@@ -449,7 +449,8 @@ namespace Antmicro.Renode.Peripherals.Analog
                 .WithReservedBits(0, 18)
                 .WithTaggedFlag("VREFEN", 22)
                 .WithTaggedFlag("TSEN", 23)
-                .WithReservedBits(25, 7);
+                .WithTaggedFlag("LFMEN", 25)
+                .WithReservedBits(26, 6);
 
             if(hasPrescaler)
             {


### PR DESCRIPTION
This fixes all open issues that blocks the STM32 ADC to run in the C0/G0/L0 devices. The related issues are:

* https://github.com/renode/renode/issues/414
* https://github.com/renode/renode/issues/542
* https://github.com/renode/renode/issues/569

This was tested using Zephyr mainline using https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/drivers/adc sample using the following branch https://github.com/nandojve/zephyr/tree/renode/fix_stm32_c0g0l0_adc.

Assuming the renode already in the path the below command allow build and run the simulation.

```shell
west build -b nucleo_g071rb deps/zephyr/samples/drivers/adc -t run
west build -b b_l072z_lrwan1 deps/zephyr/samples/drivers/adc -t run
west build -b nucleo_c031c6 deps/zephyr/samples/drivers/adc -t run
```

depends on https://github.com/antmicro/dts2repl/pull/6 and https://github.com/antmicro/dts2repl/pull/5