### PR TITLE
STM32_Timer: restrict AutoReload to 16-bits

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Timers/STM32_Timer.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/STM32_Timer.cs
@@ -310,7 +310,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                 },
                 
                 {(long)Registers.Counter, new DoubleWordRegister(this)
-                    .WithValueField(0, 32, writeCallback: (_, val) => Value = val, valueProviderCallback: _ => (uint)Value, name: "Counter value (CNT)")
+                    .WithValueField(0, 16, writeCallback: (_, val) => Value = val, valueProviderCallback: _ => (uint)Value, name: "Counter value (CNT)")
                     .WithWriteCallback((_, val) =>
                     {
                         for(var i = 0; i < NumberOfCCChannels; ++i)
@@ -325,7 +325,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                 },
 
                 {(long)Registers.Prescaler, new DoubleWordRegister(this)
-                    .WithValueField(0, 32, writeCallback: (_, val) => Divider = (int)val + 1, valueProviderCallback: _ => (uint)Divider - 1, name: "Prescaler value (PSC)")
+                    .WithValueField(0, 16, writeCallback: (_, val) => Divider = (int)val + 1, valueProviderCallback: _ => (uint)Divider - 1, name: "Prescaler value (PSC)")
                     .WithWriteCallback((_, __) =>
                     {
                         for(var i = 0; i < NumberOfCCChannels; ++i)
@@ -369,7 +369,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             {
                 var j = i;
                 registersMap.Add((long)Registers.CaptureOrCompare1 + (j * 0x4), new DoubleWordRegister(this)
-                    .WithValueField(0, 32, valueProviderCallback: _ => (uint)ccTimers[j].Limit, writeCallback: (_, val) =>
+                    .WithValueField(0, 16, valueProviderCallback: _ => (uint)ccTimers[j].Limit, writeCallback: (_, val) =>
                     {
                         if(val == 0)
                         {

--- a/src/Emulator/Peripherals/Peripherals/Timers/STM32_Timer.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/STM32_Timer.cs
@@ -337,7 +337,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                 },
 
                 {(long)Registers.AutoReload, new DoubleWordRegister(this)
-                    .WithValueField(0, 32, writeCallback: (_, val) =>
+                    .WithValueField(0, 16, writeCallback: (_, val) =>
                     {
                         autoReloadValue = (uint)val;
                         Enabled = enableRequested && autoReloadValue > 0;


### PR DESCRIPTION
The existing definition of AutoReload is 32-bits. As a result, writing `0xffffffff` into this register will have it wait for a very long time. Restrict it to 16-bits to cause the upper 16-bits to be ignored, mimicking real hardware.