### PR TITLE
STM32F4_CRC: use correct CRC data

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/CRC/STM32F4_CRC.cs
+++ b/src/Emulator/Peripherals/Peripherals/CRC/STM32F4_CRC.cs
@@ -18,7 +18,7 @@ namespace Antmicro.Renode.Peripherals.CRC
     {
         public STM32F4_CRC(IMachine machine) : base(machine)
         {
-            crc = new CRCEngine(CRCPolynomial.CRC32, init: 0xFFFFFFFF, xorOutput: 0xFFFFFFFF);
+            crc = new CRCEngine(CRCPolynomial.CRC32, init: 0xFFFFFFFF, xorOutput: 0, reflectInput: false, reflectOutput: false);
 
             DefineRegisters();
             Reset();


### PR DESCRIPTION
The STM32F4 CRC engine uses the MPEG2 polynomial and configuration. This is different from most other CRC engines, and is somewhat surprising.

This patch fixes https://github.com/renode/renode/issues/585