### PR TITLE
Feature: STM32WBA5x CRC implementation

### DIFF
--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -579,7 +579,7 @@
     <Compile Include="Peripherals\Sensors\AS6221.cs" />
     <Compile Include="Peripherals\Sensors\MAX77818.cs" />
     <Compile Include="Peripherals\I2C\LC709205F.cs" />
-    <Compile Include="Peripherals\CRC\STM32F0_CRC.cs" />
+    <Compile Include="Peripherals\CRC\STM32_CRCBase.cs" />
     <Compile Include="Peripherals\CRC\STM32F4_CRC.cs" />
     <Compile Include="Peripherals\MTD\STM32L0_FlashController.cs" />
     <Compile Include="Peripherals\MTD\STM32_FlashController.cs" />

--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -581,6 +581,7 @@
     <Compile Include="Peripherals\I2C\LC709205F.cs" />
     <Compile Include="Peripherals\CRC\STM32_CRCBase.cs" />
     <Compile Include="Peripherals\CRC\STM32F0_CRC.cs" />
+    <Compile Include="Peripherals\CRC\STM32WBA_CRC.cs" />
     <Compile Include="Peripherals\CRC\STM32F4_CRC.cs" />
     <Compile Include="Peripherals\MTD\STM32L0_FlashController.cs" />
     <Compile Include="Peripherals\MTD\STM32_FlashController.cs" />

--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -580,6 +580,7 @@
     <Compile Include="Peripherals\Sensors\MAX77818.cs" />
     <Compile Include="Peripherals\I2C\LC709205F.cs" />
     <Compile Include="Peripherals\CRC\STM32_CRCBase.cs" />
+    <Compile Include="Peripherals\CRC\STM32F0_CRC.cs" />
     <Compile Include="Peripherals\CRC\STM32F4_CRC.cs" />
     <Compile Include="Peripherals\MTD\STM32L0_FlashController.cs" />
     <Compile Include="Peripherals\MTD\STM32_FlashController.cs" />

--- a/src/Emulator/Peripherals/Peripherals/CRC/STM32F0_CRC.cs
+++ b/src/Emulator/Peripherals/Peripherals/CRC/STM32F0_CRC.cs
@@ -1,0 +1,16 @@
+//
+// Copyright (c) 2010-2024 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+
+namespace Antmicro.Renode.Peripherals.CRC
+{
+    public class STM32F0_CRC : STM32_CRCBase
+    {
+        public STM32F0_CRC(bool configurablePoly) : base(configurablePoly, IndependentDataWidth.Bits8)
+        {
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/CRC/STM32WBA_CRC.cs
+++ b/src/Emulator/Peripherals/Peripherals/CRC/STM32WBA_CRC.cs
@@ -1,0 +1,16 @@
+//
+// Copyright (c) 2010-2024 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+
+namespace Antmicro.Renode.Peripherals.CRC
+{
+    public class STM32WBA_CRC : STM32_CRCBase
+    {
+        public STM32WBA_CRC() : base(true, IndependentDataWidth.Bits32)
+        {
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/CRC/STM32_CRCBase.cs
+++ b/src/Emulator/Peripherals/Peripherals/CRC/STM32_CRCBase.cs
@@ -15,9 +15,9 @@ using Antmicro.Renode.Utilities;
 
 namespace Antmicro.Renode.Peripherals.CRC
 {
-    public class STM32F0_CRC : IBytePeripheral, IWordPeripheral, IDoubleWordPeripheral, IKnownSize
+    public class STM32_CRCBase : IBytePeripheral, IWordPeripheral, IDoubleWordPeripheral, IKnownSize
     {
-        public STM32F0_CRC(bool configurablePoly)
+        public STM32_CRCBase(bool configurablePoly)
         {
             this.configurablePoly = configurablePoly;
             var registersMap = new Dictionary<long, DoubleWordRegister>


### PR DESCRIPTION
Basically the same implementation as STM32F0_CRC
Only difference: size of IndependentData register 8 -> 32


Usage:

/* repl file */
crc: CRC.STM32WBA_CRC @ sysbus 0x40023000
    configurablePoly: true
