### PR TITLE
Fix: Macronix MX25R write with AND operation

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/SPI/Macronix_MX25R.cs
+++ b/src/Emulator/Peripherals/Peripherals/SPI/Macronix_MX25R.cs
@@ -24,15 +24,15 @@ namespace Antmicro.Renode.Peripherals.SPI
                 .WithTaggedFlag("QE (Quad Enable)", 6)
                 .WithTaggedFlag("SRWD (Status register write protect)", 7);
 
-           configurationRegister
-               .WithReservedBits(0, 3)
-               .WithFlag(3, out topBottom, name: "TB (top/bottom selected)")
-               .WithReservedBits(4, 2)
-               .WithTaggedFlag("DC (Dummy Cycle)", 6)
-               .WithReservedBits(7, 1)
-               .WithReservedBits(8, 1)
-               .WithTaggedFlag("L/H Switch", 9)
-               .WithReservedBits(10, 6);
+            configurationRegister
+                .WithReservedBits(0, 3)
+                .WithFlag(3, out topBottom, name: "TB (top/bottom selected)")
+                .WithReservedBits(4, 2)
+                .WithTaggedFlag("DC (Dummy Cycle)", 6)
+                .WithReservedBits(7, 1)
+                .WithReservedBits(8, 1)
+                .WithTaggedFlag("L/H Switch", 9)
+                .WithReservedBits(10, 6);
         }
 
         private void UpdateLockedRange(uint blockProtectionValue)

--- a/src/Emulator/Peripherals/Peripherals/SPI/Macronix_MX25R.cs
+++ b/src/Emulator/Peripherals/Peripherals/SPI/Macronix_MX25R.cs
@@ -35,6 +35,16 @@ namespace Antmicro.Renode.Peripherals.SPI
                 .WithReservedBits(10, 6);
         }
 
+        protected override void WriteToMemory(byte val)
+        {
+            if(!TryVerifyWriteToMemory(out var position))
+            {
+                return;
+            }
+            var currentVal = underlyingMemory.ReadByte(position);
+            underlyingMemory.WriteByte(position, (byte)(val & currentVal));
+        }
+
         private void UpdateLockedRange(uint blockProtectionValue)
         {
             if(blockProtectionValue == 0)


### PR DESCRIPTION
The Macronix MR25R external flash does an AND operation when writing data.
When the memory area is not erased prior writing this will lead to a verification error (done by test FW).
See the following screenshot of a real hardware output.

![image (21)](https://github.com/renode/renode-infrastructure/assets/11925556/0cff58cc-c32a-4621-bfbd-d822b8207b8a)

This PR implements the same behaviour for the peripheral.


