### PR TITLE
bugfix: update Zynq-7000 SLCR

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/Zynq7000_SystemLevelControlRegisters.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/Zynq7000_SystemLevelControlRegisters.cs
@@ -46,6 +46,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             Registers.SDIORefClockControl.Define(this).WithValueField(0, 32, FieldMode.Read, valueProviderCallback: (_) => 0x00001E03);
             Registers.GigE0RefClockControl.Define(this).WithValueField(0, 32, FieldMode.Read, valueProviderCallback: (_) => 0x00003C01);
             Registers.CPUClockRatioModeSelect.Define(this).WithValueField(0, 32, FieldMode.Read, valueProviderCallback: (_) => 1);
+            Registers.UARTRefClockControl.Define(this).WithValueField(0, 32, FieldMode.Read, valueProviderCallback: (_) => 0x3F03);
 
             Registers.WriteProtectionLock.Define(this)
                 .WithReservedBits(16, 16)


### PR DESCRIPTION
This commit adds the missing UARTRefClockControl register to the SLCR.