### PR TITLE
USBDeviceCore: Add direction parameter for GetEndpoint

### DIFF
--- a/src/Emulator/Extensions/Utilities/USBIP/USBIPServer.cs
+++ b/src/Emulator/Extensions/Utilities/USBIP/USBIPServer.cs
@@ -248,7 +248,7 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
                     }
                     else
                     {
-                        var ep = device.USBCore.GetEndpoint((int)urbHeader.EndpointNumber);
+                        var ep = device.USBCore.GetEndpoint((int)urbHeader.EndpointNumber, urbHeader.Direction == URBDirection.Out ? Direction.HostToDevice : Direction.DeviceToHost);
                         if(ep == null)
                         {
                             this.Log(LogLevel.Warning, "URB command directed to a non-existing endpoint 0x{0:X}", urbHeader.EndpointNumber);

--- a/src/Emulator/Extensions/Utilities/USBIP/USBIPServer.cs
+++ b/src/Emulator/Extensions/Utilities/USBIP/USBIPServer.cs
@@ -240,10 +240,10 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
                         var additionalData = (additionalDataCount > 0)
                             ? buffer.Skip(buffer.Count - additionalDataCount).Take(additionalDataCount).ToArray()
                             : null;
-
+                        var replyHeader = urbHeader;
                         device.USBCore.HandleSetupPacket(setupPacket, additionalData: additionalData, resultCallback: response =>
                         {
-                            SendResponse(GenerateURBReply(urbHeader, packet, response));
+                            SendResponse(GenerateURBReply(replyHeader, packet, response));
                         });
                     }
                     else

--- a/src/Emulator/Extensions/Utilities/USBIP/USBIPServer.cs
+++ b/src/Emulator/Extensions/Utilities/USBIP/USBIPServer.cs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2010-2019 Antmicro
+// Copyright (c) 2010-2024 Antmicro
 //
 // This file is licensed under the MIT License.
 // Full license text is available in 'licenses/MIT.txt'.
@@ -383,19 +383,16 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
             var currentOffset = Packet.CalculateLength<USB.ConfigurationDescriptor>();
             for(var i = 0; i < interfaceDescriptors.Length; i++)
             {
-                interfaceDescriptors[i] = Packet.Decode<USB.InterfaceDescriptor>(recursiveBytes, currentOffset);
-                if(i != interfaceDescriptors.Length - 1)
+                // the second byte of each descriptor contains the type
+                while(recursiveBytes[currentOffset + 1] != (byte)DescriptorType.Interface)
                 {
-                    // skip until the next interface descriptor
-                    currentOffset += Packet.CalculateLength<USB.InterfaceDescriptor>();
-
-                    // the second byte of each descriptor contains the type
-                    while(recursiveBytes[currentOffset + 1] != (byte)DescriptorType.Interface)
-                    {
-                        // the first byte of each descriptor contains the length in bytes
-                        currentOffset += recursiveBytes[currentOffset];
-                    }
+                    // the first byte of each descriptor contains the length in bytes
+                    currentOffset += recursiveBytes[currentOffset];
                 }
+
+                interfaceDescriptors[i] = Packet.Decode<USB.InterfaceDescriptor>(recursiveBytes, currentOffset);
+                // skip until the next interface descriptor
+                currentOffset += Packet.CalculateLength<USB.InterfaceDescriptor>();
             }
 
             return result;

--- a/src/Emulator/Main/Peripherals/USB/USBDeviceCore.cs
+++ b/src/Emulator/Main/Peripherals/USB/USBDeviceCore.cs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2010-2018 Antmicro
+// Copyright (c) 2010-2024 Antmicro
 //
 //  This file is licensed under the MIT License.
 //  Full license text is available in 'licenses/MIT.txt'.
@@ -78,7 +78,7 @@ namespace Antmicro.Renode.Core.USB
             SelectedConfiguration = null;
         }
 
-        public USBEndpoint GetEndpoint(int endpointNumber)
+        public USBEndpoint GetEndpoint(int endpointNumber, Direction direction)
         {
             if(SelectedConfiguration == null)
             {
@@ -87,7 +87,7 @@ namespace Antmicro.Renode.Core.USB
 
             foreach(var iface in SelectedConfiguration.Interfaces)
             {
-                var ep = iface.Endpoints.FirstOrDefault(x => x.Identifier == endpointNumber);
+                var ep = iface.Endpoints.FirstOrDefault(x => x.Identifier == endpointNumber && x.Direction == direction);
                 if(ep != null)
                 {
                    return ep;

--- a/src/Emulator/Peripherals/Peripherals/SPI/MAX3421E.cs
+++ b/src/Emulator/Peripherals/Peripherals/SPI/MAX3421E.cs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2010-2023 Antmicro
+// Copyright (c) 2010-2024 Antmicro
 //
 // This file is licensed under the MIT License.
 // Full license text is available in 'licenses/MIT.txt'.
@@ -425,7 +425,7 @@ namespace Antmicro.Renode.Peripherals.SPI
                 USBEndpoint endpoint = null;
                 if(ep != 0)
                 {
-                    endpoint = device.USBCore.GetEndpoint((int)ep);
+                    endpoint = device.USBCore.GetEndpoint((int)ep, outnin ? Direction.HostToDevice : Direction.DeviceToHost);
                     if(endpoint == null)
                     {
                         this.Log(LogLevel.Error, "Tried to access a non-existing EP #{0}", ep);

--- a/src/Emulator/Peripherals/Peripherals/USB/MPFS_USB.cs
+++ b/src/Emulator/Peripherals/Peripherals/USB/MPFS_USB.cs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2010-2018 Antmicro
+// Copyright (c) 2010-2024 Antmicro
 //
 //  This file is licensed under the MIT License.
 //  Full license text is available in 'licenses/MIT.txt'.
@@ -433,7 +433,7 @@ namespace Antmicro.Renode.Peripherals.USB
                                 return;
                             }
 
-                            var endpoint = peripheral.USBCore.GetEndpoint((int)receiveTargetEndpointNumber[endpointId].Value);
+                            var endpoint = peripheral.USBCore.GetEndpoint((int)receiveTargetEndpointNumber[endpointId].Value, Direction.DeviceToHost);
                             if(endpoint == null)
                             {
                                 this.Log(LogLevel.Warning, "Trying to read from a non-existing endpoint #{0}", receiveTargetEndpointNumber[endpointId].Value);
@@ -498,7 +498,7 @@ namespace Antmicro.Renode.Peripherals.USB
                             }
 
                             var mappedEndpointId = (int)transmitTargetEndpointNumber[endpointId].Value;
-                            var endpoint = peripheral.USBCore.GetEndpoint(mappedEndpointId);
+                            var endpoint = peripheral.USBCore.GetEndpoint(mappedEndpointId, Direction.HostToDevice);
                             if(endpoint == null)
                             {
                                 this.Log(LogLevel.Warning, "Trying to write to a non-existing endpoint #{0}", mappedEndpointId);


### PR DESCRIPTION
DeviceToHost and HostToDevice endpoints can share a same endpoint number, so it is better to distinguish an endpoint by both number and direction.