### PR TITLE
SynopsysDWEthernet: Fix typo in Rx log message

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Network/SynopsysDWCEthernetQualityOfService/SynopsysDWCEthernetQualityOfService_DMA.cs
+++ b/src/Emulator/Peripherals/Peripherals/Network/SynopsysDWCEthernetQualityOfService/SynopsysDWCEthernetQualityOfService_DMA.cs
@@ -180,7 +180,7 @@ namespace Antmicro.Renode.Peripherals.Network
                                 rxFinishedRing &= !clearRxFinishedRing;
                                 StartRx();
                             }
-                            this.Log(LogLevel.Debug, "Receive Tail register (DMACRxDTPR.RDT) set to: 0x{0:X}", txDescriptorRingTail.Value);
+                            this.Log(LogLevel.Debug, "Receive Tail register (DMACRxDTPR.RDT) set to: 0x{0:X}", rxDescriptorRingTail.Value);
                         }, name: "DMACRxDTPR.RDT (Receive Descriptor Tail Pointer)")
                     },
                     {(long)RegistersDMAChannel.TxDescriptorRingLength + offset, new DoubleWordRegister(parent)


### PR DESCRIPTION
The log message printing the Rx DMA ring tail register was wrongly printing the the Tx DMA ring tail register.