### PR TITLE
implement mtvt CSR to support CLIC vectored mode

### DIFF
--- a/src/Emulator/Cores/RiscV/RegisterDescription.cs
+++ b/src/Emulator/Cores/RiscV/RegisterDescription.cs
@@ -393,7 +393,8 @@ namespace Antmicro.Renode.Peripherals.CPU
                 csrGroup.Registers.Add(new GDBRegisterDescriptor((uint)RiscV32Registers.MEDELEG, registerWidth, "medeleg", intType, "csr"));
                 csrGroup.Registers.Add(new GDBRegisterDescriptor((uint)RiscV32Registers.MIDELEG, registerWidth, "mideleg", intType, "csr"));
             }
-
+            
+            csrGroup.Registers.Add(new GDBRegisterDescriptor((uint)RiscV32Registers.MTVT, registerWidth, "mtvt","", "csr"));
             csrGroup.Registers.Add(new GDBRegisterDescriptor((uint)RiscV32Registers.MSTATUS, registerWidth, "mstatus", "", "csr"));
             csrGroup.Registers.Add(new GDBRegisterDescriptor((uint)RiscV32Registers.MISA, registerWidth, "misa", "", "csr"));
             csrGroup.Registers.Add(new GDBRegisterDescriptor((uint)RiscV32Registers.MIE, registerWidth, "mie", "mie_type", "csr"));

--- a/src/Emulator/Cores/RiscV/RiscV32Registers.cs
+++ b/src/Emulator/Cores/RiscV/RiscV32Registers.cs
@@ -278,6 +278,18 @@ namespace Antmicro.Renode.Peripherals.CPU
             }
         }
         [Register]
+        public RegisterValue MTVT
+        {
+            get
+            {
+                return GetRegisterValue32((int)RiscV32Registers.MTVT);
+            }
+            set
+            {
+                SetRegisterValue32((int)RiscV32Registers.MTVT, value);
+            }
+        }
+        [Register]
         public RegisterValue MSTATUS
         {
             get
@@ -773,6 +785,7 @@ namespace Antmicro.Renode.Peripherals.CPU
             { RiscV32Registers.STVAL,  new CPURegister(388, 32, isGeneral: false, isReadonly: false, aliases: new [] { "STVAL" }) },
             { RiscV32Registers.SIP,  new CPURegister(389, 32, isGeneral: false, isReadonly: false, aliases: new [] { "SIP" }) },
             { RiscV32Registers.SATP,  new CPURegister(449, 32, isGeneral: false, isReadonly: false, aliases: new [] { "SATP", "SPTBR" }) },
+            { RiscV32Registers.MTVT,  new CPURegister(775, 32, isGeneral: false, isReadonly: false, aliases: new [] { "MTVT" }) },
             { RiscV32Registers.MSTATUS,  new CPURegister(833, 32, isGeneral: false, isReadonly: false, aliases: new [] { "MSTATUS" }) },
             { RiscV32Registers.MISA,  new CPURegister(834, 32, isGeneral: false, isReadonly: false, aliases: new [] { "MISA" }) },
             { RiscV32Registers.MEDELEG,  new CPURegister(835, 32, isGeneral: false, isReadonly: false, aliases: new [] { "MEDELEG" }) },
@@ -811,6 +824,7 @@ namespace Antmicro.Renode.Peripherals.CPU
         SIP = 389,
         SATP = 449,
         SPTBR = 449,
+        MTVT= 775,
         MSTATUS = 833,
         MISA = 834,
         MEDELEG = 835,


### PR DESCRIPTION
1. Implement mtvt to provide support of CLIC vectored mode in RV32 architecture.
2. Following renode console shows support of MTVT CSR .So that firmware that uses CLIC vectored mode can be run and tested    on renode. It is tested on zephyr for andes based RV32 SoC. 
![Screenshot from 2024-12-04 01-07-35](https://github.com/user-attachments/assets/e465a77a-8329-42cd-b4b0-f7ca0bb8dcd9)
3.Required support is also added in tlib.
https://github.com/antmicro/tlib/pull/17


