### PR TITLE
Network: CadenceGEM: do not leave DMA descriptors unassigned

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Network/CadenceGEM.cs
+++ b/src/Emulator/Peripherals/Peripherals/Network/CadenceGEM.cs
@@ -460,10 +460,11 @@ namespace Antmicro.Renode.Peripherals.Network
 
         public override void Reset()
         {
+            uint value = 0x00000000;
             registers.Reset();
             interruptManager.Reset();
-            txDescriptorsQueue = null;
-            rxDescriptorsQueue = null;
+            txDescriptorsQueue = new DmaBufferDescriptorsQueue<DmaTxBufferDescriptor>(sysbus, (uint)value << 2, (sb, addr) => new DmaTxBufferDescriptor(sb, addr, dmaAddressBusWith.Value, extendedTxBufferDescriptorEnabled.Value));
+            rxDescriptorsQueue = new DmaBufferDescriptorsQueue<DmaRxBufferDescriptor>(sysbus, (uint)value << 2, (sb, addr) => new DmaRxBufferDescriptor(sb, addr, dmaAddressBusWith.Value, extendedRxBufferDescriptorEnabled.Value));
             phyDataRead = 0;
             isTransmissionStarted = false;
             nanoTimer.Reset();


### PR DESCRIPTION
Cadence proprietary driver code is reading registers values of TX and RX dma descriptions before assigning value to them.

In the current state, Renode will crash because it is accessing null pointers.

To fix this issue we assign reset values and allocate dummy descriptors to handle this scenario.