### PR TITLE
Update ARM and NVIC models for Sleep-on-exit flag support

### DIFF
--- a/src/Emulator/Cores/Arm-M/CortexM.cs
+++ b/src/Emulator/Cores/Arm-M/CortexM.cs
@@ -58,6 +58,11 @@ namespace Antmicro.Renode.Peripherals.CPU
             base.Reset();
         }
 
+        public void SetSleepOnExceptionExit(bool value)
+        {
+            tlibSetSleepOnExceptionExit(value ? 1 : 0);
+        }
+
         protected override void OnResume()
         {
             // Suppress initialization when processor is turned off as binary may not even be loaded yet
@@ -456,6 +461,9 @@ namespace Antmicro.Renode.Peripherals.CPU
 
         [Import]
         private Func<uint> tlibIsV8;
+
+        [Import]
+        private Action<int> tlibSetSleepOnExceptionExit;
 
         /* PMSAv8 MPU */
         [Import]

--- a/src/Emulator/Cores/Arm-M/NVIC.cs
+++ b/src/Emulator/Cores/Arm-M/NVIC.cs
@@ -460,6 +460,14 @@ namespace Antmicro.Renode.Peripherals.IRQControllers
             }
         }
 
+        public void SetSleepOnExceptionExitOnAllCPUs(bool value)
+        {
+            foreach(var cpu in machine.SystemBus.GetCPUs().OfType<CortexM>())
+            {
+                cpu.SetSleepOnExceptionExit(value);
+            }
+        }
+
         public DoubleWordRegisterCollection RegisterCollection { get; }
 
         public bool DeepSleepEnabled => deepSleepEnabled.Value;
@@ -579,7 +587,8 @@ namespace Antmicro.Renode.Peripherals.IRQControllers
 
             Registers.SystemControlRegister.Define(RegisterCollection)
                 .WithReservedBits(0, 1)
-                .WithTaggedFlag("SLEEPONEXIT", 1)
+                .WithFlag(1, out sleepOnExitEnabled, name: "SLEEPONEXIT",
+                    changeCallback: (_, value) => SetSleepOnExceptionExitOnAllCPUs(value))
                 .WithFlag(2, out deepSleepEnabled, name: "SLEEPDEEP")
                 .WithReservedBits(3, 1)
                 .WithFlag(4, out currentSevOnPending, name: "SEVONPEND",
@@ -1290,6 +1299,7 @@ namespace Antmicro.Renode.Peripherals.IRQControllers
         private readonly IMachine machine;
         private uint cpuId;
 
+        private IFlagRegisterField sleepOnExitEnabled;
         private IFlagRegisterField deepSleepEnabled;
         private IFlagRegisterField currentSevOnPending;
 


### PR DESCRIPTION
Support for ARM Cortex-M SLEEPONEXIT flag.
This goes with changes in the tlib repo as well: https://github.com/antmicro/tlib/pull/18