### PR TITLE
STM32F7_I2C: Fix error message condition for NBYTES change when START is set

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/I2C/STM32F7_I2C.cs
+++ b/src/Emulator/Peripherals/Peripherals/I2C/STM32F7_I2C.cs
@@ -153,6 +153,7 @@ namespace Antmicro.Renode.Peripherals.I2C
                         .WithReservedBits(27, 5)
                         .WithWriteCallback((oldVal, newVal) =>
                         {
+                            uint oldStart = (oldVal >> 13) & 1;
                             uint oldBytesToTransfer = (oldVal >> 16) & 0xFF;
 
                             if(start.Value && stop.Value)
@@ -175,9 +176,13 @@ namespace Antmicro.Renode.Peripherals.I2C
                                     ExtendTransfer();
                                 }
                             }
-                            else if(oldBytesToTransfer != bytesToTransfer.Value)
+
+                            if(oldStart == 1)
                             {
-                                this.Log(LogLevel.Error, "Changing NBYTES when START is set is not permitted");
+                                if(oldBytesToTransfer != bytesToTransfer.Value)
+                                {
+                                    this.Log(LogLevel.Error, "Changing NBYTES when START is set is not permitted");
+                                }
                             }
 
                             start.Value = false;


### PR DESCRIPTION
It looks like the NBYTES and START bit should be allowed to change simultaneously. Otherwise even standard STM32 HAL logic causes this error.

Reference manual says that NBYTES cannot be change only if START is already set:

![i2c2_ds](https://github.com/user-attachments/assets/f84f6e17-72bd-4ce0-82ec-174122d4104c)
