### PR TITLE
Work around ModuleBuilder.GetType exception

### DIFF
--- a/src/Emulator/Main/Utilities/Binding/NativeBinder.cs
+++ b/src/Emulator/Main/Utilities/Binding/NativeBinder.cs
@@ -362,7 +362,7 @@ namespace Antmicro.Renode.Utilities.Binding
         {
             var baseName = returnType == typeof(void) ? "Action" : "Func" + returnType.Name;
             var paramNames = parameterTypes.Select(p => p.Name);
-            return string.Join("", paramNames.Prepend(baseName));
+            return string.Join("", paramNames.Prepend(baseName)).Replace("[]", "Array");
         }
 
         private static string GetCName(string name)


### PR DESCRIPTION
ModuleBuilder.GetType throws an exception when "[]" is in the type name but Array seems to be okay.