### PR TITLE
Monitor: Re-register ourself with Machines after the Emulation is changed

### DIFF
--- a/src/Emulator/Extensions/UserInterface/Monitor.cs
+++ b/src/Emulator/Extensions/UserInterface/Monitor.cs
@@ -113,6 +113,10 @@ namespace Antmicro.Renode.UserInterface
                 aliases.Clear();
                 Machine = null;
                 emulationManager.CurrentEmulation.MachineAdded += RegisterResetCommand;
+                foreach (var mach in emulationManager.CurrentEmulation.Machines)
+                {
+                    RegisterResetCommand(mach);
+                }
                 monitorPath.Reset();
             };
 


### PR DESCRIPTION
When an emulation is loaded from a file, EmulationChanged called only after all the machines have already been deserialized. To ensure we've registered our reset command callback, manually register each existing machine.

Fixes: 160f4d18 ("Initial commit of the Emul8 framework.")