### PR TITLE
Machine: Invoke MachineReset in RequestResetInSafeState

### DIFF
--- a/src/Emulator/Main/Core/Machine.cs
+++ b/src/Emulator/Main/Core/Machine.cs
@@ -567,6 +567,11 @@ namespace Antmicro.Renode.Core
                     {
                         peripheral.Reset();
                     }
+                    var machineReset = MachineReset;
+                    if(machineReset != null)
+                    {
+                        machineReset(this);
+                    }
                 }
                 postReset?.Invoke();
             };


### PR DESCRIPTION
Make RequestResetInSafeState invoke MachineReset so that registered actions (such as Monitor.ResetMachine) get called just like they do for RequestReset. This ensures we invoke the same actions after a watchdog reset as we do after a cold reset.