### PR TITLE
Logging: FileBackend: Allow passing non-sequenced paths

### DIFF
--- a/src/Emulator/Main/Logging/Backends/FileBackend.cs
+++ b/src/Emulator/Main/Logging/Backends/FileBackend.cs
@@ -14,7 +14,7 @@ namespace Antmicro.Renode.Logging
 {
     public class FileBackend : TextBackend
     {
-        public FileBackend(SequencedFilePath filePath, bool flushAfterEachWrite = false)
+        public FileBackend(WriteFilePath filePath, bool flushAfterEachWrite = false)
         {
             var stream = File.Open(filePath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
             output = new StreamWriter(stream);


### PR DESCRIPTION
Some files, such as named pipes or /dev/stdout, shouldn't be moved. Allow passing non-sequenced paths to the file logging backend to support this use case.