### PR TITLE
TimeHandle: Initialize TotalElapsedTime to NearestSyncPoint

### DIFF
--- a/src/Emulator/Main/Time/TimeHandle.cs
+++ b/src/Emulator/Main/Time/TimeHandle.cs
@@ -118,8 +118,8 @@ namespace Antmicro.Renode.Time
         {
             lock(innerLock)
             {
-                DebugHelper.Assert(TimeSource.ElapsedVirtualTime >= TotalElapsedTime, $"Trying to move time handle back in time from: {TotalElapsedTime} to {TimeSource.ElapsedVirtualTime}");
-                TotalElapsedTime = TimeSource.ElapsedVirtualTime;
+                DebugHelper.Assert(TimeSource.NearestSyncPoint >= TotalElapsedTime, $"Trying to move time handle back in time from: {TotalElapsedTime} to {TimeSource.NearestSyncPoint}");
+                TotalElapsedTime = TimeSource.NearestSyncPoint;
             }
         }
 


### PR DESCRIPTION
When registering a new TimeHandle, IsReadyForNewTimeGrant will be true. However, other handles may have already been granted time. The TimeSource will wait for these other active handles to finish (causing their TotalElapsedTime to increase). After all all active handles have finished, SynchronizeVirtualTime will attempt to update the TimeSource's ElapsedVirtualTime. However, the newly-added handle's TotalElapsedTime will still be the source's ElapsedVirtualTime from when the handle was added. This will prevent time from advancing. This will cause ExecuteSyncPhase to fail, since ElapsedVirtualTime will not equal NearestSyncPoint.

Fix this by initializing TimeHandle.TotalElapsedTime to TimeSource.NearestSyncPoint, which is the earliest time that time will be granted to the handle.

Fixes: 49d06a36 ("[#8661] Introduce new time framework.")