### PR TITLE
Implement AHB3Reset registers for STM32H7

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/STM32H7_RCC.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/STM32H7_RCC.cs
@@ -92,6 +92,19 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                     .WithFlag(1, FieldMode.Read, valueProviderCallback: _ => lsion.Value, name: "LSIRDY")
                     .WithReservedBits(2, 30)
                 },
+                {(long)Registers.AHB3Reset, new DoubleWordRegister(this, 0x0)
+                    .WithFlag(0, name: "MDMARST")
+                    .WithReservedBits(1, 3)
+                    .WithFlag(4, name: "DMA2DRST")
+                    .WithFlag(5, name: "JPGDECRST")
+                    .WithReservedBits(6, 6)
+                    .WithFlag(12, name: "FMCRST")
+                    .WithReservedBits(13, 1)
+                    .WithFlag(14, name: "QSPIRST")
+                    .WithReservedBits(15, 1)
+                    .WithFlag(16, name: "SDMMC1RST")
+                    .WithReservedBits(17, 15)
+                },
                 {(long)Registers.AHB4Enable, new DoubleWordRegister(this, 0x0)
                     .WithFlag(0, name: "GPIOAEN")
                     .WithFlag(1, name: "GPIOBEN")
@@ -164,6 +177,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             // ...
             BackupDomainControl = 0x70,
             ClockControlAndStatus = 0x74,
+            AHB3Reset = 0x7C,
             // ...
             AHB4Enable = 0xE0
         }


### PR DESCRIPTION
Implements AHB3Reset registers for STM32H7.
Please refer to the reference manual:
https://www.st.com/resource/en/reference_manual/rm0433-stm32h742-stm32h743753-and-stm32h750-value-line-advanced-armbased-32bit-mcus-stmicroelectronics.pdf

8.7.28
![image](https://github.com/user-attachments/assets/720e580d-a453-4e69-ab06-4365257d3329)
