### PR TITLE
[#769] Fix msp430 entering/exiting Interrupt handlers 

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/CPU/MSP430X/MSP430X.cs
+++ b/src/Emulator/Peripherals/Peripherals/CPU/MSP430X/MSP430X.cs
@@ -435,7 +435,7 @@ namespace Antmicro.Renode.Peripherals.CPU
             var interruptVector = InterruptVectorStart - (ulong)interruptNumber * 2U;
             var interruptAddress = (ushort)PerformMemoryRead(interruptVector, AccessWidth._16bit);
 
-            var statusAndPC = ((PC & 0xF0000U) >> 8) | SR;
+            var statusAndPC = ((PC & 0xF0000U) >> 4) | SR;
 
             SP -= 2U;
             PerformMemoryWrite(SP, PC, AccessWidth._16bit);
@@ -845,7 +845,7 @@ namespace Antmicro.Renode.Peripherals.CPU
 
                                 newPC = PerformMemoryRead(SP, AccessWidth._16bit);
                                 SP += 2U;
-                                newPC |= (ushort)((statusAndPC & 0xF000) << 4);
+                                newPC |= (uint)((statusAndPC & 0xF000) << 4);
                                 PC = newPC;
                             }
                             else


### PR DESCRIPTION
This PR fixes https://github.com/renode/renode/issues/769

### Description

To support 20-bit extension of PC, MSP430X does following:
* When entering the interrupt handlers, it pushes the higher 4bits of SP with SR contents.
* When exiting the interrupt handlers, it pops two words for the SR (12bits) and PC(20bits)

The current implementation loses the higher 4bits in PC of the original context.
<img width="1115" alt="Screenshot 2025-03-18 at 12 03 36" src="https://github.com/user-attachments/assets/f697f64b-da1b-4d6c-b408-9a7bcee1898a" />


