### PR TITLE
[#773] msp430: Fix ADDA/SUBA with constant generator

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/CPU/MSP430X/MSP430X.cs
+++ b/src/Emulator/Peripherals/Peripherals/CPU/MSP430X/MSP430X.cs
@@ -767,7 +767,12 @@ namespace Antmicro.Renode.Peripherals.CPU
                 else
                 {
                     var sourceRegister = (Registers)((instr & 0x0F00) >> 8);
-                    sourceValue = GetRegisterValue(sourceRegister);
+                    // ADDA R2/3,Rdst and SUBA R2/3,Rdst should read the CG in IndirectRegister mode
+                    if ((sourceRegister == Registers.SR || sourceRegister == Registers.R3) && (funcIdentifier & 0xE) == 0xE) {
+                        sourceValue = GetRegisterValue(sourceRegister, AddressingMode.IndirectRegister);
+                    } else {
+                        sourceValue = GetRegisterValue(sourceRegister);
+                    }
                 }
 
                 switch(funcIdentifier & 0x3)


### PR DESCRIPTION
This PR fixes https://github.com/renode/renode/issues/773

### Description

Seems like this is an undocumented behavior of MSP430X though..., ADDA and SUBA instructions behave uniquely when accessing R2 and R3, which are constant generators.

Currently in renode "adda R3, Rdst" does nothing. This looks correct as far as I read through the documentation, but actually, on physical devices, it does increment the destination register by 2.

adda r3, r4 --> increment r4 by 2
suba r2, r4 --> recrement r4 by 4

Please see the related discussion in TI E2E forum for details and the code to reproduce it.

https://e2e.ti.com/support/microcontrollers/msp-low-power-microcontrollers-group/msp430/f/msp-low-power-microcontroller-forum/1489338/msp430fr5969-addressing-mode-of-cg-r3-for-adda-and-suba-instructions
