### PR TITLE
Fix: Correct ARM register mapping in GDB feature descriptor

### DIFF
--- a/src/Emulator/Cores/Arm-M/CortexM.cs
+++ b/src/Emulator/Cores/Arm-M/CortexM.cs
@@ -123,12 +123,12 @@ namespace Antmicro.Renode.Peripherals.CPU
                 features.Add(mProfileFeature);
 
                 var mSystemFeature = new GDBFeatureDescriptor("org.gnu.gdb.arm.m-system");
-                mSystemFeature.Registers.Add(new GDBRegisterDescriptor(26, 32, "msp", "uint32", "general"));
-                mSystemFeature.Registers.Add(new GDBRegisterDescriptor(27, 32, "psp", "uint32", "general"));
+                mSystemFeature.Registers.Add(new GDBRegisterDescriptor(18, 32, "control", "uint32", "general"));
+                mSystemFeature.Registers.Add(new GDBRegisterDescriptor(19, 32, "basepri", "uint32", "general"));
+                mSystemFeature.Registers.Add(new GDBRegisterDescriptor(21, 32, "msp", "data_ptr", "general"));
+                mSystemFeature.Registers.Add(new GDBRegisterDescriptor(22, 32, "psp", "data_ptr", "general"));
                 mSystemFeature.Registers.Add(new GDBRegisterDescriptor(28, 32, "primask", "uint32", "general"));
-                mSystemFeature.Registers.Add(new GDBRegisterDescriptor(29, 32, "basepri", "uint32", "general"));
                 mSystemFeature.Registers.Add(new GDBRegisterDescriptor(30, 32, "faultmask", "uint32", "general"));
-                mSystemFeature.Registers.Add(new GDBRegisterDescriptor(31, 32, "control", "uint32", "general"));
                 features.Add(mSystemFeature);
 
                 return features;


### PR DESCRIPTION
- Updated register indices for `control`, `basepri`, `msp`, and `psp` to align with expected mapping.  
- Changed `msp` and `psp` types from `uint32` to `data_ptr` to correctly represent stack pointers.  
- Reordered `mSystemFeature` registers for consistency.  

This ensures proper GDB register representation for ARM debugging.