### PR TITLE
Fix broken README link to point to correct file in Renode repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
 README
 ======
 
-See `Renode README.rst <https://www.github.com/renode/renode/blob/master/README.rst>`_.
+See `Renode README.rst <https://github.com/renode/renode/blob/main/README.md>`_.

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
 README
 ======
 
-See `Renode README.rst <https://github.com/renode/renode/blob/main/README.md>`_.
+See `Renode README.rst <https://github.com/renode/renode/blob/master/README.md>`_.


### PR DESCRIPTION
This pull request updates the broken link in the README file.

Previously, the link pointed to a non-existent README.rst file in the Renode repository, resulting in a 404 error.
This update corrects the link to point to the correct README.md file.

I am submitting this change to help improve navigation for users and to assist in maintaining the quality of the project. 

Thank you for your time and consideration!