### PR TITLE
Unexpected PSM event during deepsleep with Quectel Modem

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Network/QuectelModem.cs
+++ b/src/Emulator/Peripherals/Peripherals/Network/QuectelModem.cs
@@ -691,6 +691,7 @@ namespace Antmicro.Renode.Peripherals.Network
             // Entering deep sleep is equivalent to a power off, so we do a reset here.
             // NVRAM values will be preserved.
             Reset();
+            powerSavingModeActive = true;
         }
 
         protected void EnableModem()


### PR DESCRIPTION
During renode testing it was noticed that there was an issue with the quectel modem emulation file.
There was unexpected PSM_ENTER event when we were already in the deep sleep state.
It looked to be an incorrect sequence and we were able to resolve the issue locally and have our tests running again.

The problem here was that in the last Reset() call the SetPowerSavingMode(true) is called before internally setting the state flag powerSavingModeActive to true to protect against multiple same events.
But this flag and also some other flags are reset directly in the Reset() and after this call finally we have powerSavingModeActive=false.
This means that next call of SetPowerSavingMode(true) will generate an additional kind of unexpected event PSM_ENTER.

Our workaround was to explicitly set powerSavingModeActive to true after Reset().