### PR TITLE
Feature/multiple cs files include

### DIFF
--- a/src/Emulator/Extensions/UserInterface/Commands/IncludeFileCommand.cs
+++ b/src/Emulator/Extensions/UserInterface/Commands/IncludeFileCommand.cs
@@ -6,6 +6,7 @@
 // Full license text is available in 'licenses/MIT.txt'.
 //
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using Antmicro.Renode.UserInterface.Tokenizer;
 using AntShell.Commands;
@@ -21,33 +22,60 @@ namespace Antmicro.Renode.UserInterface.Commands
         {
             base.PrintHelp(writer);
 
-            writer.WriteLine("\nTo load a script you have to provide an existing file name.");
+            writer.WriteLine("\nTo load script(s) you have to provide one (or more) existing file name(s).");
             writer.WriteLine();
             writer.WriteLine("Supported file formats:");
-            writer.WriteLine("*.cs   - plugin file");
+            writer.WriteLine("*.cs   - plugin file(s)");
             writer.WriteLine("*.py   - python script");
             writer.WriteLine("*.repl - platform description file");
             writer.WriteLine("other  - monitor script");
         }
 
         [Runnable]
-        public bool Run(ICommandInteraction writer, StringToken path)
+        public bool Run(ICommandInteraction writer, params StringToken[] paths)
         {
-            return Run(writer, path.Value);
+            var filePaths = paths.Select(n => new ReadFilePath(n.Value)).ToArray();
+            return Run(writer, filePaths);
         }
 
-        private bool Run(ICommandInteraction writer, ReadFilePath path)
+        private bool Run(ICommandInteraction writer, ReadFilePath[] paths)
         {
-            using(var progress = EmulationManager.Instance.ProgressMonitor.Start("Including script: " + path))
+            using(var progress = EmulationManager.Instance.ProgressMonitor.Start("Including script(s): " + String.Join(" ", paths.Select(nameof => nameof.ToString()))))
             {
                 bool result = false;
-                switch(Path.GetExtension(path))
+
+                var path = paths[0];
+                var ext = Path.GetExtension(path);
+
+                // Validate all extensions are the same as the first one
+                for(var i = 1; i < paths.Length; i++)
+                {
+                    var checkExt = Path.GetExtension(paths[i]);
+                    if(checkExt != ext)
+                    {
+                        writer.WriteError($"All file extensions must match (saw {ext} and {checkExt})!");
+                        return false;
+                    }
+                }
+
+                // Only allow multiple include files for *.cs
+                if(ext != ".cs")
+                {
+                    if(paths.Length > 1)
+                    {
+                        writer.WriteError($"Inclusion of muliple files in currently only supported for *.cs!");
+                        return false;
+                    }
+                }
+
+                switch(ext)
                 {
                 case ".py":
                     result = PythonExecutor(path, writer);
                     break;
                 case ".cs":
-                    result = CsharpExecutor(path, writer);
+                    var pathsStrArray = paths.Select(n => n.ToString()).ToArray();
+                    result = CsharpExecutor(pathsStrArray, writer);
                     break;
                 case ".repl":
                     result = ReplExecutor(path, writer);
@@ -62,11 +90,11 @@ namespace Antmicro.Renode.UserInterface.Commands
         }
 
         private readonly Func<string,bool> ScriptExecutor;
-        private readonly Func<string, ICommandInteraction, bool> CsharpExecutor;
+        private readonly Func<string[], ICommandInteraction, bool> CsharpExecutor;
         private readonly Func<string, ICommandInteraction, bool> PythonExecutor;
         private readonly Func<string, ICommandInteraction, bool> ReplExecutor;
 
-        public IncludeFileCommand(Monitor monitor, Func<string, ICommandInteraction, bool> pythonExecutor, Func<string, bool> scriptExecutor, Func<string, ICommandInteraction, bool> csharpExecutor, Func<string, ICommandInteraction, bool> replExecutor) : base(monitor, "include", "loads a Monitor script, Python code, platform file or a plugin class.", "i")
+        public IncludeFileCommand(Monitor monitor, Func<string, ICommandInteraction, bool> pythonExecutor, Func<string, bool> scriptExecutor, Func<string [], ICommandInteraction, bool> csharpExecutor, Func<string, ICommandInteraction, bool> replExecutor) : base(monitor, "include", "loads a Monitor script, Python code, platform file or a plugin class.", "i")
         {
             this.CsharpExecutor = csharpExecutor;
             this.PythonExecutor = pythonExecutor;

--- a/src/Emulator/Extensions/UserInterface/Monitor.cs
+++ b/src/Emulator/Extensions/UserInterface/Monitor.cs
@@ -325,7 +325,12 @@ namespace Antmicro.Renode.UserInterface
                         return null;
                     }
                     // replace the last token with the expanded version
-                    var newString = result.Tokens.Take(result.Tokens.Count() - 1).Select(x => x.OriginalValue).Stringify() + lastExpandedToken.OriginalValue + cmd.Substring(cmd.Length - result.UnmatchedCharactersLeft);
+                    var newString = String.Concat(
+                        result.Tokens.Take(result.Tokens.Count() - 1).Select(x => x.OriginalValue).Stringify(),
+                        " ",
+                        lastExpandedToken.OriginalValue,
+                        cmd.Substring(cmd.Length - result.UnmatchedCharactersLeft)
+                    );
                     return Tokenize(newString, writer);
                 }
                 var messages = new StringBuilder();

--- a/src/Emulator/Extensions/UserInterface/Monitor.cs
+++ b/src/Emulator/Extensions/UserInterface/Monitor.cs
@@ -592,8 +592,9 @@ namespace Antmicro.Renode.UserInterface
             return DisposableWrapper.New(() => _currentMachine = activeMachine);
         }
 
-        public bool TryCompilePlugin(string filename, ICommandInteraction writer = null)
+        public bool TryCompilePlugin(string[] filenames, ICommandInteraction writer = null)
         {
+            var filename = filenames[0];
             if(writer == null)
             {
                 writer = Interaction;

--- a/src/Emulator/Extensions/UserInterface/Monitor.cs
+++ b/src/Emulator/Extensions/UserInterface/Monitor.cs
@@ -625,7 +625,7 @@ namespace Antmicro.Renode.UserInterface
                 if(!EmulationManager.Instance.CompiledFilesCache.TryGetEntryWithSha(sha, out var compiledCode))
                 {
                     var compiler = new AdHocCompiler();
-                    compiledCode = compiler.Compile(filename);
+                    compiledCode = compiler.Compile(new[] { filename });
                     // Load dynamically compiled assembly to memory. It presents an advantage that next
                     // ad-hoc compiled assembly can reference types from this one without any extra steps.
                     // Therefore "EnsureTypeIsLoaded" call is no necessary as dependencies are already loaded.

--- a/src/Emulator/Main/Tests/UnitTests/AdHocCompilerTests.cs
+++ b/src/Emulator/Main/Tests/UnitTests/AdHocCompilerTests.cs
@@ -25,7 +25,7 @@ namespace Antmicro.Renode.Utilities
         public void ShouldNotThrowOnEmptyFile()
         {
             var extension = TemporaryFilesManager.Instance.GetTemporaryFile();
-            Assert.DoesNotThrow(() => { file = adhoc.Compile(extension); });
+            Assert.DoesNotThrow(() => { file = adhoc.Compile(new[] { extension }); });
             Assert.IsTrue(manager.ScanFile(file));
         }
 
@@ -35,7 +35,7 @@ namespace Antmicro.Renode.Utilities
             var extension = GetType().Assembly.FromResourceToTemporaryFile("MockExtension.cs");
             var methodsBefore = manager.GetExtensionMethods(typeof(Emulation));
             Assert.IsFalse(methodsBefore.Any(x => x.Name == "GetMockString"));
-            Assert.DoesNotThrow(() => { file = adhoc.Compile(extension); });
+            Assert.DoesNotThrow(() => { file = adhoc.Compile(new[] { extension }); });
             Assert.IsTrue(manager.ScanFile(file));
             var methodsAfter = manager.GetExtensionMethods(typeof(Emulation));
             Assert.IsNotEmpty(methodsAfter);

--- a/src/Emulator/Main/Utilities/AdHocCompiler.cs
+++ b/src/Emulator/Main/Utilities/AdHocCompiler.cs
@@ -16,7 +16,7 @@ namespace Antmicro.Renode.Utilities
 {
     public class AdHocCompiler
     {
-        public string Compile(string sourcePath)
+        public string Compile(string[] sourcePaths)
         {
             var outputFileName = TemporaryFilesManager.Instance.GetTemporaryFile();
             var parameters = new List<string>();
@@ -45,7 +45,10 @@ namespace Antmicro.Renode.Utilities
             parameters.Add("/noconfig");
 
             parameters.Add("--");
-            parameters.Add(sourcePath);
+            foreach (var sourcePath in sourcePaths)
+            {
+                parameters.Add(sourcePath);
+            }
 
             var result = false;
             var errorOutput = new StringWriter();


### PR DESCRIPTION
Support doing adhoc compilation of multiple .cs files. The intention is to support partial class implementations where the interfaces for a peripheral's registers are autogenerated (possibly repeatedly during pre-silicon development stages) and the modeling of the registers is maintained in a separate file with implementation details that can evolve and be more fully fleshed out over time. Without changes such as these the contents of these two files have to be concatenated and edited (the primary edit being the stripping `using` directives from the second file) and then included by the Renode monitor.