### PR TITLE
user/emedve/rsfdp-dummy-cycles

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/SPI/GenericSpiFlash.cs
+++ b/src/Emulator/Peripherals/Peripherals/SPI/GenericSpiFlash.cs
@@ -211,6 +211,7 @@ namespace Antmicro.Renode.Peripherals.SPI
             switch(command)
             {
                 case Commands.FastRead:
+                case Commands.ReadSerialFlashDiscoveryParameter:
                     return 1;
                 default:
                     return 0;


### PR DESCRIPTION
GenericSpiFlash: Observe dummy cycles for RSFDP

Per JESD216, section 4.3:

> Following the address, eight dummy clocks (8 wait states) are required before
> valid data is clocked out.

Currently the code is not waiting out the dummy cycles on `SI` and starts pushing out the SFDP bytes early on `SO` thus the controller is missing the first byte from the magic/parameters

renode/renode#824