### PR TITLE
RISCV Compressed Instructions (Zcb, Zcmp, Zcmt estensions)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/Emulator/Cores/tlib"]
 	path = src/Emulator/Cores/tlib
-	url = https://github.com/antmicro/tlib.git
+	url = https://github.com/SiliconLabsSoftware/renode-tlib.git 

--- a/src/Emulator/Cores/RiscV/BaseRiscV.cs
+++ b/src/Emulator/Cores/RiscV/BaseRiscV.cs
@@ -1435,6 +1435,9 @@ namespace Antmicro.Renode.Peripherals.CPU
             ZVE64D = 13,
             ZACAS = 14,
             SSCOFPMF = 15,
+            ZCB = 16,
+            ZCMP = 17,
+            ZCMT = 18,
         }
 
         public enum InterruptMode
@@ -1645,6 +1648,12 @@ namespace Antmicro.Renode.Peripherals.CPU
                 case "ZVE64F": standardExtensions.Add(StandardInstructionSetExtensions.ZVE64F); break;
                 case "ZVE64D": standardExtensions.Add(StandardInstructionSetExtensions.ZVE64D); break;
                 case "ZACAS": standardExtensions.Add(StandardInstructionSetExtensions.ZACAS); break;
+                case "ZCA": 
+                    instructionSets.Add(InstructionSet.C); // ZCA maps to base C extension
+                    break;
+                case "ZCB": standardExtensions.Add(StandardInstructionSetExtensions.ZCB); break;
+                case "ZCMP": standardExtensions.Add(StandardInstructionSetExtensions.ZCMP); break;
+                case "ZCMT": standardExtensions.Add(StandardInstructionSetExtensions.ZCMT); break;                
                 default:
                     throw new ConstructionException($"Undefined instructions set extension: '{name}'");
                 }

--- a/src/Emulator/Cores/RiscV/RiscV32Registers.cs
+++ b/src/Emulator/Cores/RiscV/RiscV32Registers.cs
@@ -174,6 +174,20 @@ namespace Antmicro.Renode.Peripherals.CPU
         }
 
         [Register]
+        public RegisterValue JVT
+        {
+            get
+            {
+                return GetRegisterValue32((int)RiscV32Registers.JVT);
+            }
+
+            set
+            {
+                SetRegisterValue32((int)RiscV32Registers.JVT, value);
+            }
+        }
+
+        [Register]
         public RegisterValue SSTATUS
         {
             get
@@ -871,6 +885,7 @@ namespace Antmicro.Renode.Peripherals.CPU
             { RiscV32Registers.F31,  new CPURegister(64, 64, isGeneral: false, isReadonly: false, aliases: new [] { "F31" }) },
             { RiscV32Registers.FFLAGS,  new CPURegister(65, 32, isGeneral: false, isReadonly: false, aliases: new [] { "FFLAGS" }) },
             { RiscV32Registers.FRM,  new CPURegister(66, 32, isGeneral: false, isReadonly: false, aliases: new [] { "FRM" }) },
+            { RiscV32Registers.JVT,  new CPURegister(88, 32, isGeneral: false, isReadonly: false, aliases: new [] { "JVT" }) },
             { RiscV32Registers.VSTART,  new CPURegister(101, 32, isGeneral: false, isReadonly: false, aliases: new [] { "VSTART" }) },
             { RiscV32Registers.VXSAT,  new CPURegister(102, 32, isGeneral: false, isReadonly: false, aliases: new [] { "VXSAT" }) },
             { RiscV32Registers.VXRM,  new CPURegister(103, 32, isGeneral: false, isReadonly: false, aliases: new [] { "VXRM" }) },
@@ -912,6 +927,7 @@ namespace Antmicro.Renode.Peripherals.CPU
         TP = 4,
         FP = 8,
         PC = 32,
+        JVT = 88,
         SSTATUS = 321,
         SIE = 325,
         STVEC = 326,

--- a/src/Emulator/Cores/RiscV/RiscV64Registers.cs
+++ b/src/Emulator/Cores/RiscV/RiscV64Registers.cs
@@ -174,6 +174,20 @@ namespace Antmicro.Renode.Peripherals.CPU
         }
 
         [Register]
+        public RegisterValue JVT
+        {
+            get
+            {
+                return GetRegisterValue64((int)RiscV64Registers.JVT);
+            }
+
+            set
+            {
+                SetRegisterValue64((int)RiscV64Registers.JVT, value);
+            }
+        }
+
+        [Register]
         public RegisterValue SSTATUS
         {
             get
@@ -871,6 +885,7 @@ namespace Antmicro.Renode.Peripherals.CPU
             { RiscV64Registers.F31,  new CPURegister(64, 64, isGeneral: false, isReadonly: false, aliases: new [] { "F31" }) },
             { RiscV64Registers.FFLAGS,  new CPURegister(65, 32, isGeneral: false, isReadonly: false, aliases: new [] { "FFLAGS" }) },
             { RiscV64Registers.FRM,  new CPURegister(66, 32, isGeneral: false, isReadonly: false, aliases: new [] { "FRM" }) },
+            { RiscV64Registers.JVT,  new CPURegister(88, 64, isGeneral: false, isReadonly: false, aliases: new [] { "JVT" }) },
             { RiscV64Registers.VSTART,  new CPURegister(101, 64, isGeneral: false, isReadonly: false, aliases: new [] { "VSTART" }) },
             { RiscV64Registers.VXSAT,  new CPURegister(102, 64, isGeneral: false, isReadonly: false, aliases: new [] { "VXSAT" }) },
             { RiscV64Registers.VXRM,  new CPURegister(103, 64, isGeneral: false, isReadonly: false, aliases: new [] { "VXRM" }) },
@@ -912,6 +927,7 @@ namespace Antmicro.Renode.Peripherals.CPU
         TP = 4,
         FP = 8,
         PC = 32,
+        JVT = 88,
         SSTATUS = 321,
         SIE = 325,
         STVEC = 326,


### PR DESCRIPTION
- tlib: Implemented RISCV Zcb, Zcmp and Zcmt extensions
- BaseRiscV class: handle ZCB, ZCMP, ZCMT extensions enablement
- Regenerated RiscV Registers files:
  * t4 -p BASE_PATH="$(pwd)/src" RiscV32Registers.tt
  * t4 -p BASE_PATH="$(pwd)/src" RiscV64Registers.tt