### PR TITLE
Set IO_MEM_EXECUTABLE_IO for all non-IMapped peripherals

### DIFF
--- a/src/Emulator/Main/Core/Machine.cs
+++ b/src/Emulator/Main/Core/Machine.cs
@@ -1027,10 +1027,11 @@ namespace Antmicro.Renode.Core
                 }
             }
 
-            // Register io_executable flags for all ArrayMemory peripherals
+            // Register io_executable flags for all non-IMapped peripherals so that
+            // instruction fetches from them go through I/O callbacks instead of aborting.
             foreach(var context in SystemBus.GetAllContextKeys())
             {
-                foreach(var registration in SystemBus.GetRegistrationsForPeripheralType<Peripherals.Memory.ArrayMemory>(context))
+                foreach(var registration in SystemBus.GetRegistrationsForPeripheralType<IBusPeripheral>(context).Where(r => !(r.Peripheral is IMapped)))
                 {
                     var range = registration.RegistrationPoint.Range;
                     var perCore = registration.RegistrationPoint.Initiator;

--- a/src/Emulator/Main/Peripherals/Bus/SystemBus.cs
+++ b/src/Emulator/Main/Peripherals/Bus/SystemBus.cs
@@ -1260,7 +1260,7 @@ namespace Antmicro.Renode.Peripherals.Bus
                 AddMappingsForPeripheral(peripheral, newRegistration, context);
             }
 
-            if(peripheral is ArrayMemory)
+            if(!(peripheral is IMapped))
             {
                 foreach(var cpu in GetCPUsForContext<ICPUWithMappedMemory>(context))
                 {
@@ -2054,6 +2054,16 @@ namespace Antmicro.Renode.Peripherals.Bus
                 });
                 // let's add new mappings
                 AddMappingsForPeripheral(peripheral, registrationPoint, context);
+                // For non-IMapped peripherals, mark the range as executable I/O so that
+                // instruction fetches go through I/O callbacks instead of causing cpu_abort.
+                if(!(peripheral is IMapped))
+                {
+                    foreach(var cpu in GetCPUsForContext<ICPUWithMappedMemory>(context))
+                    {
+                        var range = registrationPoint.Range;
+                        cpu.RegisterAccessFlags(range.StartAddress, range.Size, isIoMemory: true);
+                    }
+                }
                 // After adding new mappings, if the address range is locked, the mappings possibly have to be modified/unmapped on the CPU's side
                 // RelockRange to make this happen
                 if(IsAddressRangeLocked(registrationPoint.Range, context))


### PR DESCRIPTION
## Summary
- Generalizes the `IO_MEM_EXECUTABLE_IO` flag from `ArrayMemory`-only to all non-`IMapped` peripherals
- Fixes cpu_abort when executing code from dynamically compiled C# peripherals that don't implement `IMapped`
- Three changes: `RegisterInner`, `MoveRegistrationWithinContext`, and `PostCreationActions`

Fixes #877