### PR TITLE
Fix xspi flash operations

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/SPI/Cadence_xSPICommands/PIOCommands.cs
+++ b/src/Emulator/Peripherals/Peripherals/SPI/Cadence_xSPICommands/PIOCommands.cs
@@ -218,6 +218,9 @@ namespace Antmicro.Renode.Peripherals.SPI.Cadence_xSPICommands
             {
                 if(dataTransmittedCount == 0)
                 {
+                    // NOTE: Set WriteEnable
+                    Peripheral.Transmit(WriteEnableOperation);
+                    Peripheral.FinishTransmission();
                     Peripheral.Transmit(PageProgram4ByteOperation);
                     TransmitAddress();
                 }

--- a/src/Emulator/Peripherals/Peripherals/SPI/GenericSpiFlash.cs
+++ b/src/Emulator/Peripherals/Peripherals/SPI/GenericSpiFlash.cs
@@ -246,9 +246,9 @@ namespace Antmicro.Renode.Peripherals.SPI
                 currentOperation.AddressLength = 3;
                 break;
             case (byte)Commands.FastRead:
-                // fast read - 3 bytes of address + a dummy byte
+                // fast read - 3 or 4 bytes of address (depending on mode) + a dummy byte
                 currentOperation.Operation = DecodedOperation.OperationType.ReadFast;
-                currentOperation.AddressLength = 3;
+                currentOperation.AddressLength = NumberOfAddressBytes;
                 currentOperation.State = DecodedOperation.OperationState.AccumulateCommandAddressBytes;
                 break;
             case (byte)Commands.Read:


### PR DESCRIPTION
- FastRead command now respects the current addressing mode instead of always using 3-byte addressing
- PIO write path now sends WriteEnable before PageProgram, matching the DMA path