### PR TITLE
WFE performance busy wait improvement

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/CPU/BaseCPU.cs
+++ b/src/Emulator/Peripherals/Peripherals/CPU/BaseCPU.cs
@@ -792,14 +792,13 @@ namespace Antmicro.Renode.Peripherals.CPU
                             this.Trace();
                             var instructionsToSkip = Math.Min(InstructionsToNearestLimit(), instructionsLeftThisRound);
 
-                            virtualTimeAhead = machine.LocalTimeSource.ElapsedVirtualHostTimeDifference;
-                            if(!machine.LocalTimeSource.AdvanceImmediately && virtualTimeAhead.Ticks > 0 && instructionsToSkip > 0)
+                            if(!machine.LocalTimeSource.AdvanceImmediately && instructionsToSkip > 0)
                             {
-                                // Don't fall behind realtime by sleeping
-                                var intervalToSleep = TimeInterval.FromCPUCycles(instructionsToSkip, PerformanceInMips, out var cyclesResiduum).WithTicksMin(virtualTimeAhead.Ticks);
+                                // Sleep for the full remaining quantum while waiting for an interrupt.
+                                // sleeper.Interrupt() from OnGPIO will wake us early when an IRQ arrives,
+                                // so we only burn host CPU for the actual wait duration, not the full quantum.
+                                var intervalToSleep = TimeInterval.FromCPUCycles(instructionsToSkip, PerformanceInMips, out var cyclesResiduum);
                                 sleeper.Sleep(intervalToSleep.ToTimeSpan(out var nsResiduum), out var intervalSlept);
-                                // If we have a CPU of less than 10 MIPS, it might be the case that the interval slept (which is in units of 100 ns)
-                                // is less than 1 instruction. Just round up it in this case.
                                 instructionsToSkip = Math.Max(TimeInterval.FromTimeSpan(intervalSlept, nsResiduum).ToCPUCycles(PerformanceInMips, out var _) + cyclesResiduum, 1);
                             }
 


### PR DESCRIPTION
Change for WFE performance:


* BaseCPU: Sleep for the full remaining quantum during WFI/WFE instead of only the real-time pacing delta. sleeper.Interrupt() from OnGPIO wakes the thread early when an IRQ arrives, so host CPU usage drops from 100% to near-idle during WFE/WFI wait loops.
* in conjunction with fixing https://github.com/renode/renode/issues/892