### PR TITLE
[893] CortexM: expose RequestTranslationBlockInterrupt for precise bus fault modeling

### DIFF
--- a/src/Emulator/Cores/Arm-M/CortexM.cs
+++ b/src/Emulator/Cores/Arm-M/CortexM.cs
@@ -670,6 +670,17 @@ namespace Antmicro.Renode.Peripherals.CPU
             }
         }
 
+        /// <summary>
+        /// Requests an abort of the currently executing instruction inside the
+        /// translation block.  When excludeLastInstruction is true the CPU state
+        /// is restored to the start of the faulting instruction (PC points to
+        /// it), modelling a synchronous precise fault that can be retried.
+        /// </summary>
+        public void RequestTranslationBlockInterrupt(bool excludeLastInstruction)
+        {
+            TlibRequestTranslationBlockInterrupt(excludeLastInstruction ? 1 : 0);
+        }
+
         public bool SecureState
         {
             get

--- a/src/Emulator/Cores/Arm-M/CortexM.cs
+++ b/src/Emulator/Cores/Arm-M/CortexM.cs
@@ -670,17 +670,6 @@ namespace Antmicro.Renode.Peripherals.CPU
             }
         }
 
-        /// <summary>
-        /// Requests an abort of the currently executing instruction inside the
-        /// translation block.  When excludeLastInstruction is true the CPU state
-        /// is restored to the start of the faulting instruction (PC points to
-        /// it), modelling a synchronous precise fault that can be retried.
-        /// </summary>
-        public void RequestTranslationBlockInterrupt(bool excludeLastInstruction)
-        {
-            TlibRequestTranslationBlockInterrupt(excludeLastInstruction ? 1 : 0);
-        }
-
         public bool SecureState
         {
             get

--- a/src/Emulator/Peripherals/Peripherals/CPU/TranslationCPU.cs
+++ b/src/Emulator/Peripherals/Peripherals/CPU/TranslationCPU.cs
@@ -432,6 +432,18 @@ namespace Antmicro.Renode.Peripherals.CPU
             return pauseGuard.RequestTranslationBlockRestart(quiet);
         }
 
+        /// <summary>
+        /// Requests an abort of the currently executing instruction inside the
+        /// translation block. When <paramref name="excludeLastInstruction"/> is
+        /// true the CPU state is restored to the start of the faulting
+        /// instruction (PC points to it), modelling a synchronous precise fault
+        /// that can be retried.
+        /// </summary>
+        public void RequestTranslationBlockInterrupt(bool excludeLastInstruction)
+        {
+            TlibRequestTranslationBlockInterrupt(excludeLastInstruction ? 1 : 0);
+        }
+
         public uint AssembleBlock(ulong addr, string instructions, string triple = null, bool alternateDialect = false)
         {
             if(Assembler == null)


### PR DESCRIPTION
Peripherals that model synchronous bus faults need to abort the current translation block so the stacked PC in the exception frame points at the faulting instruction, matching real Cortex-M hardware behavior. 
Expose the existing tlib mechanism as a public method on CortexM so peripheral models can call it to produce precise faults with correct CFSR.PRECISERR semantics.