### PR TITLE
SAM4S_EEFC: Report FRDY=0 briefly after command write

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/SAM4S_EEFC.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/SAM4S_EEFC.cs
@@ -266,6 +266,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                         return;
                     }
 
+                    flashBusy = true;
                     ExecuteFlashCommand((Commands)command.Value, (int)argument.Value);
                     IRQ.Set(generateInterrupt.Value);
                 })
@@ -273,7 +274,17 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
 
             Registers.Status.Define(this)
                 .WithFlag(0, FieldMode.Read, name: "FRDY",
-                    valueProviderCallback: _ => true)
+                    valueProviderCallback: _ =>
+                    {
+                        // After a command write, report busy once so firmware
+                        // sees the FRDY=0 transition, then ready on next read.
+                        if(flashBusy)
+                        {
+                            flashBusy = false;
+                            return false;
+                        }
+                        return true;
+                    })
                 .WithTaggedFlag("FCMDE", 1)
                 .WithFlag(2, out triedWriteLocked, FieldMode.ReadToClear, name: "FLOCKE")
                 .WithFlag(3, out commandError, FieldMode.ReadToClear, name: "FLERR")
@@ -289,6 +300,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         private IFlagRegisterField generateInterrupt;
         private IFlagRegisterField triedWriteLocked;
         private IFlagRegisterField commandError;
+        private bool flashBusy;
 
         private readonly IMemory underlyingMemory;
         private readonly uint flashIdentifier;


### PR DESCRIPTION
The EEFC model previously always returned FRDY=1 in the status register. Firmware (e.g. ASF's efc_perform_read_sequence running from RAM) polls EEFC_FSR waiting for the FRDY=0 transition that indicates the flash controller has accepted a command. Without this transition the firmware spins forever.

Set a flashBusy flag on command write and return FRDY=0 on the first subsequent status read, then FRDY=1 on the next read. This matches real hardware behaviour where FRDY briefly goes low.

### Note

This is part of a larger effort to properly emulate SAM4E-based devices. I'll create some more PRs related to that; this note applies to all of them so I'll only put it here.

We are in need of SAM4E support in renode. The SAM4S support means it's *mostly* there, just some fixes here and there. Now I'm not very well versed in emulator development, so I've had Claude have a crack at it while looking at the datasheet and observing our firmware running in renode. It's working pretty well now, but the code is all AI-generated. I'm not sure what your stance on this is; it certainly needs review from someone knowledgable in the area. I've glanced over the code and I think it's okay-ish from my POV. No tests though; and I don't know if you require them.

In any case, we'd be happy to contribute the changes back upstream.