### PR TITLE
SAM_SPI: Fix IndexOutOfRangeException in SetDmaAccessWidth

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/SPI/SAM_SPI.cs
+++ b/src/Emulator/Peripherals/Peripherals/SPI/SAM_SPI.cs
@@ -357,7 +357,15 @@ namespace Antmicro.Renode.Peripherals.SPI
             }
             else
             {
-                DmaWriteAccessWidth = txLengths[SelectedSlaveRegisterNumber] > 0 ? TransferType.Word : TransferType.Byte;
+                var slaveRegNum = SelectedSlaveRegisterNumber;
+                if(slaveRegNum >= txLengths.Length)
+                {
+                    DmaWriteAccessWidth = TransferType.Byte;
+                }
+                else
+                {
+                    DmaWriteAccessWidth = txLengths[slaveRegNum] > 0 ? TransferType.Word : TransferType.Byte;
+                }
             }
         }
 


### PR DESCRIPTION
When the SPI Mode Register PCS field is set to 0xF (no chip select active), ChipSelect() computes selectedSlaveAddr=4 via GetLeastSignificantZero/Logarithm2.  SetDmaAccessWidth() then accesses txLengths[4] which is out of bounds for the 4-element array (indices 0-3), causing an unhandled IndexOutOfRangeException that crashes the emulation.

Guard the array access in SetDmaAccessWidth() and fall back to byte-width DMA when the computed slave register number exceeds the array bounds.

This is part of a larger effort to properly emulate SAM4E-based devices.