### PR TITLE
Machine: add Uid property

### DIFF
--- a/src/Emulator/Main/Core/Machine.cs
+++ b/src/Emulator/Main/Core/Machine.cs
@@ -41,6 +41,7 @@ namespace Antmicro.Renode.Core
     {
         public Machine(bool createLocalTimeSource = false)
         {
+            machineUid = ++count;
             atomicState = new AtomicState(this);
 
             collectionSync = new object();
@@ -1305,6 +1306,8 @@ namespace Antmicro.Renode.Core
             }
         }
 
+        public ulong Uid => machineUid;
+
         public Platform Platform { get; set; }
 
         public bool IsPaused
@@ -1894,8 +1897,10 @@ namespace Antmicro.Renode.Core
 
         private readonly MultiTree<IPeripheral, IRegistrationPoint> registeredPeripherals;
         private readonly object disposedSync;
+        private readonly ulong machineUid;
 
         private const int InitialDirtyListLength = 1 << 16;
+        private static ulong count = 0;
 
         private sealed class PausedState : IDisposable
         {

--- a/src/Emulator/Main/Peripherals/IMachine.cs
+++ b/src/Emulator/Main/Peripherals/IMachine.cs
@@ -168,6 +168,8 @@ namespace Antmicro.Renode.Core
 
         Platform Platform { get; set; }
 
+        ulong Uid { get; }
+
         bool IsPaused { get; }
 
         TimeStamp ElapsedVirtualTime { get; }


### PR DESCRIPTION
Expose a per-machine ulong Uid on IMachine/Machine, assigned from a static counter at machine construction time.