### PR TITLE
[#914] OpenTitan_AES: Slice key array to match requested key size

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/OpenTitan_AES.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/OpenTitan_AES.cs
@@ -246,7 +246,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 this.Log(LogLevel.Error, "Invalid KEY_LEN size: '0x{0:x}'. Undefined behavior ahead!", keyLength.Value);
                 return false;
             }
-            aes.Key = useSideloadedKey.Value ? sideloadKey : key;
+            // Slice the key to the requested KeySize to prevent AesManaged from forcing 256-bit operation
+            var selectedKey = useSideloadedKey.Value ? sideloadKey : key;
+            var actualKey = new byte[aes.KeySize / 8];
+            Array.Copy(selectedKey, actualKey, actualKey.Length);
+            aes.Key = actualKey;
 #if DEBUG
             this.Log(LogLevel.Debug, "Generated key: {0}", Misc.Stringify(key, " "));
 #endif

--- a/src/Emulator/Peripherals/Test/PeripheralsTests/OpenTitan_AES_Test.cs
+++ b/src/Emulator/Peripherals/Test/PeripheralsTests/OpenTitan_AES_Test.cs
@@ -52,7 +52,7 @@ namespace Antmicro.Renode.PeripheralsTests
         {
             SetKeyShare();
 
-            peripheral.WriteDoubleWord((long)OpenTitan_AES.Registers.Control, 0x205);
+            peripheral.WriteDoubleWord((long)OpenTitan_AES.Registers.Control, 0x405);
             WriteInputData(decrypted);
 
             for(int i = 0; i < 4; i++)
@@ -94,7 +94,7 @@ namespace Antmicro.Renode.PeripheralsTests
         {
             SetKeyShare();
 
-            peripheral.WriteDoubleWord((long)OpenTitan_AES.Registers.Control, 0x206);
+            peripheral.WriteDoubleWord((long)OpenTitan_AES.Registers.Control, 0x406);
 
             WriteInputData(encrypted);
 
@@ -139,7 +139,7 @@ namespace Antmicro.Renode.PeripheralsTests
         {
             SetKeyShare();
 
-            peripheral.WriteDoubleWord((long)OpenTitan_AES.Registers.Control, 0x206);
+            peripheral.WriteDoubleWord((long)OpenTitan_AES.Registers.Control, 0x406);
 
             WriteInputData(decrypted);
             WriteInputData(encrypted);


### PR DESCRIPTION
Fixes renode/renode#914