### PR TITLE
Out-of-memory fix for halted CPU in simulation

### DIFF
--- a/src/Emulator/Main/Core/Machine.cs
+++ b/src/Emulator/Main/Core/Machine.cs
@@ -1765,10 +1765,25 @@ namespace Antmicro.Renode.Core
                 .Where(pair => pair.Key.Architecture == cpu.Architecture)
                 .ToArray();
 
-            var firstUnread = sameArchitectureCPUs.Select(pair => pair.Value).Min();
+            // Halted CPUs only need to invalidate latest dirty address. Prune all previous stale address entries
+            // to prevent the unbounded growth in this list if the CPU is halted indefinitely.
+            var currentCount = invalidatedAddressesByCpu[cpu].Count;
+            foreach(var pair in sameArchitectureCPUs)
+            {
+                if((pair.Key == cpu || pair.Key.IsHalted) && pair.Value < currentCount)
+                {
+                    firstUnbroadcastedDirtyAddressIndex[pair.Key] = currentCount;
+                }
+            }
+
+            var firstUnread = sameArchitectureCPUs
+                .Select(pair => firstUnbroadcastedDirtyAddressIndex[pair.Key])
+                .Min();
             if(firstUnread == 0)
             {
-                var laggingCPUNames = sameArchitectureCPUs.Where(pair => pair.Value == 0).Select(pair => pair.Key.GetName());
+                var laggingCPUNames = sameArchitectureCPUs
+                    .Where(pair => firstUnbroadcastedDirtyAddressIndex[pair.Key] == 0)
+                    .Select(pair => pair.Key.GetName());
                 cpu.DebugLog(
                     "Attempted reduction of {0} dirty addresses list failed, current count: {1}, CPUs that didn't fetch any: {2}",
                     cpu.Architecture, invalidatedAddressesByCpu[cpu].Count, string.Join(", ", laggingCPUNames));

--- a/src/Emulator/Peripherals/Peripherals/CPU/BaseCPU.cs
+++ b/src/Emulator/Peripherals/Peripherals/CPU/BaseCPU.cs
@@ -283,6 +283,8 @@ namespace Antmicro.Renode.Peripherals.CPU
                             EmulationState = EmulationCPUState.Running;
                         }
 
+                        OnIsHaltedCleared();
+
                         if(wasRunningWhenHalted)
                         {
                             Resume();
@@ -514,6 +516,10 @@ namespace Antmicro.Renode.Peripherals.CPU
         protected virtual void OnLeavingResetState()
         {
             // Intentionally left blank.
+        }
+
+        protected virtual void OnIsHaltedCleared()
+        {
         }
 
         protected override void OnResume()

--- a/src/Emulator/Peripherals/Peripherals/CPU/TranslationCPU.cs
+++ b/src/Emulator/Peripherals/Peripherals/CPU/TranslationCPU.cs
@@ -768,6 +768,11 @@ namespace Antmicro.Renode.Peripherals.CPU
             }
         }
 
+        protected override void OnIsHaltedCleared()
+        {
+            ClearTranslationCache();
+        }
+
         public void InitStoreTable(bool afterDeserialization = false)
         {
             TlibStoreTableInit(StoreTablePointer, (byte)StoreTableBits, afterDeserialization ? 1 : 0);


### PR DESCRIPTION
This PR proposes a suggested fix for https://github.com/renode/renode/issues/920.

This modifies the `Machine`'s handling of a `TranslationCpu`'s dirty addresses broadcast. When multiple CPUs of the same architecture are present in a platform definition, and if any of the CPUs are in a halted state, avoid accumulating multiple address invalidation entries in order to avoid unbounded growth in the list. Once the CPU is unhalted, flush the full translation cache.

The out-of-memory issue is resolved when using the reproduction steps from the above issue