### PR TITLE
[#941] NVIC: Correct ICSR RETTOBASE behavior

### DIFF
--- a/src/Emulator/Cores/Arm-M/NVIC.cs
+++ b/src/Emulator/Cores/Arm-M/NVIC.cs
@@ -773,7 +773,7 @@ namespace Antmicro.Renode.Peripherals.IRQControllers
             Registers.InterruptControlState.Define(RegisterCollection)
                 .WithValueField(0, 9, FieldMode.Read, valueProviderCallback: _ => (uint)(activeIRQs.Count == 0 ? 0 : activeIRQs.Peek()), name: "VECTACTIVE")
                 .WithReservedBits(9, 2)
-                .WithTaggedFlag("RETTOBASE", 11)
+                .WithFlag(11, FieldMode.Read, valueProviderCallback: _ => IsReturnToBaseAvailable() && activeIRQs.Count <= 1, name: "RETTOBASE")
                 .WithValueField(12, 9, FieldMode.Read, valueProviderCallback: _ => (ulong)(FindPendingInterrupt() ?? 0), name: "VECTPENDING")
                 .WithReservedBits(21, 1)
                 .WithTaggedFlag("ISRPENDING", 22)
@@ -1114,6 +1114,13 @@ namespace Antmicro.Renode.Peripherals.IRQControllers
              * If there is an address here, it's always valid */
             Registers.SecureFaultAddress.Define(RegisterCollection)
                 .WithValueField(0, 32, FieldMode.Read, valueProviderCallback: _ => isNextAccessSecure ? cpu.SecureFaultAddress : 0, name: "Address");
+        }
+
+        private bool IsReturnToBaseAvailable()
+        {
+            // Armv6-M does not implement RETTOBASE. Cortex-M0 emulation exposes Armv7 features for compatibility,
+            // so ArchitectureVersion cannot be used to distinguish these models.
+            return cpu == null || (cpu.Model != "cortex-m0" && cpu.Model != "cortex-m0+" && cpu.Model != "cortex-m1");
         }
 
         private void DefineTightlyCoupledMemoryControlRegisters()

--- a/src/Emulator/Cores/Arm-M/NVIC.cs
+++ b/src/Emulator/Cores/Arm-M/NVIC.cs
@@ -1074,7 +1074,7 @@ namespace Antmicro.Renode.Peripherals.IRQControllers
             Registers.InterruptControlState.Define(RegisterCollection)
                 .WithValueField(0, 9, FieldMode.Read, valueProviderCallback: _ => (uint)(activeIRQs.Count == 0 ? 0 : activeIRQs.Peek()), name: "VECTACTIVE")
                 .WithReservedBits(9, 2)
-                .WithFlag(11, FieldMode.Read, valueProviderCallback: _ => activeIRQs.Intersect(Enum.GetValues(typeof(SystemException)).Cast<int>()).Count() <= 1, name: "RETTOBASE")
+                .WithFlag(11, FieldMode.Read, valueProviderCallback: _ => IsReturnToBaseAvailable() && activeIRQs.Count <= 1, name: "RETTOBASE")
                 .WithValueField(12, 9, FieldMode.Read, valueProviderCallback: _ => (ulong)(FindPendingInterrupt() ?? 0), name: "VECTPENDING")
                 .WithReservedBits(21, 1)
                 .WithTaggedFlag("ISRPENDING", 22)
@@ -1761,6 +1761,14 @@ namespace Antmicro.Renode.Peripherals.IRQControllers
              * If there is an address here, it's always valid */
             Registers.SecureFaultAddress.Define(RegisterCollection)
                 .WithValueField(0, 32, FieldMode.Read, valueProviderCallback: _ => isNextAccessSecure ? cpu.SecureFaultAddress : 0, name: "Address");
+        }
+
+        private bool IsReturnToBaseAvailable()
+        {
+            // Armv6-M and Armv8-M Baseline do not implement RETTOBASE. Cortex-M0 emulation exposes Armv7 features
+            // for compatibility, so ArchitectureVersion cannot be used to distinguish all of these models.
+            return cpu == null || (cpu.Model != "cortex-m0" && cpu.Model != "cortex-m0+" && cpu.Model != "cortex-m1"
+                && cpu.Model != "cortex-m23");
         }
 
         private void DefineTightlyCoupledMemoryControlRegisters()

--- a/src/Emulator/Peripherals/Test/PeripheralsTests/NVICTests.cs
+++ b/src/Emulator/Peripherals/Test/PeripheralsTests/NVICTests.cs
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2026 John Elliott
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+
+using System.Collections.Generic;
+using System.Reflection;
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Peripherals.IRQControllers;
+
+using NUnit.Framework;
+
+namespace Antmicro.Renode.UnitTests
+{
+    [TestFixture]
+    public class NVICTests
+    {
+        [TestCase(0, true)]
+        [TestCase(1, true)]
+        [TestCase(2, false)]
+        public void ShouldReportReturnToBaseAccordingToActiveExceptionCount(int activeExceptionCount, bool expected)
+        {
+            using(var machine = new Machine())
+            {
+                var nvic = new NVIC(machine);
+                var activeIRQsField = typeof(NVIC).GetField("activeIRQs", BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.That(activeIRQsField, Is.Not.Null);
+                var activeIRQs = (Stack<int>)activeIRQsField.GetValue(nvic);
+                for(var i = 0; i < activeExceptionCount; i++)
+                {
+                    activeIRQs.Push(i + 1);
+                }
+
+                Assert.That(IsReturnToBaseSet(nvic), Is.EqualTo(expected));
+            }
+        }
+
+        private static bool IsReturnToBaseSet(NVIC nvic)
+        {
+            return (nvic.ReadDoubleWord(InterruptControlState) & ReturnToBase) != 0;
+        }
+
+        private const long InterruptControlState = 0xD04;
+        private const uint ReturnToBase = 1u << 11;
+    }
+}

--- a/src/Emulator/Peripherals/Test/PeripheralsTests/NVICTests.cs
+++ b/src/Emulator/Peripherals/Test/PeripheralsTests/NVICTests.cs
@@ -1,0 +1,50 @@
+//
+// Copyright (c) 2026 John Elliott
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+
+using System.Collections.Generic;
+using System.Reflection;
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Peripherals.IRQControllers;
+
+using NUnit.Framework;
+
+namespace Antmicro.Renode.UnitTests
+{
+    [TestFixture]
+    public class NVICTests
+    {
+        [TestCase(0, true)]
+        [TestCase(1, true)]
+        [TestCase(2, false)]
+        public void ShouldReportReturnToBaseAccordingToActiveExternalInterruptCount(int activeExceptionCount, bool expected)
+        {
+            using(var machine = new Machine())
+            {
+                var nvic = new NVIC(machine);
+                var activeIRQsField = typeof(NVIC).GetField("activeIRQs", BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.That(activeIRQsField, Is.Not.Null);
+                var activeIRQs = (Stack<int>)activeIRQsField.GetValue(nvic);
+                for(var i = 0; i < activeExceptionCount; i++)
+                {
+                    activeIRQs.Push(ExternalInterruptOffset + i);
+                }
+
+                Assert.That(IsReturnToBaseSet(nvic), Is.EqualTo(expected));
+            }
+        }
+
+        private static bool IsReturnToBaseSet(NVIC nvic)
+        {
+            return (nvic.ReadDoubleWord(InterruptControlState) & ReturnToBase) != 0;
+        }
+
+        private const long InterruptControlState = 0xD04;
+        private const uint ReturnToBase = 1u << 11;
+        private const int ExternalInterruptOffset = 16;
+    }
+}


### PR DESCRIPTION
### Related issue

Fixes renode/renode#941

### Description

Corrects the read-only `ICSR.RETTOBASE` bit for Armv7-M and Armv8-M Mainline cores.

After this PR was opened, master independently implemented RETTOBASE in renode/renode-infrastructure@bd7f752f. That implementation counts only active `SystemException` values, so it ignores active external interrupts (exception numbers 16 and above). This version counts the complete active exception stack: the bit is set for zero or one active exception and clear for nested active exceptions.

Cortex-M0, Cortex-M0+, Cortex-M1, and Cortex-M23 keep bit 11 at zero. Armv6-M reserves the field, and Armv8-M Baseline does not implement it without the Main Extension.

The explicit model check is needed because Renode currently exposes Armv7 compatibility features for the Cortex-M0 family.

Regression tests cover zero, one, and two active external interrupts.

### Usage example

The reproduction from renode/renode#941 reports bit 11 set for an idle Cortex-M4 NVIC. A native matrix also verifies every currently supported Cortex-M model.

### Additional information

Validated on macOS Arm64 with .NET 8:

- targeted `NVICTests`: 3 passed, 0 failed
- full headless Release build: succeeded with 0 errors
- full managed solution: 1,115 passed, 17 existing skips, 0 failures
- scoped `dotnet format --verify-no-changes` on both changed files: passed
- native Cortex-M0/M0+/M1/M23/M3/M4/M4F/M7/M33/M52/M55/M85 matrix: passed; bit 11 is zero on M0/M0+/M1/M23 and set for the remaining idle models
