### PR TITLE
[#942] STM32_GPIOPort: Separate IDR and ODR state

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/STM32_GPIOPort.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/STM32_GPIOPort.cs
@@ -216,12 +216,12 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     .WithReservedBits(16, 16)
                 },
                 {(long)Registers.BitSet, new DoubleWordRegister(this)
-                    .WithValueField(0, 16, FieldMode.Write,
-                        writeCallback: (_, val) => { if(val != 0) WriteOutputState((ushort)(BitHelper.GetValueFromBitsArray(outputLatch) | val)); },
-                        name: "GPIOx_BS")
                     .WithValueField(16, 16, FieldMode.Write,
                         writeCallback: (_, val) => { if(val != 0) WriteOutputState((ushort)(BitHelper.GetValueFromBitsArray(outputLatch) & ~val)); },
                         name: "GPIOx_BR")
+                    .WithValueField(0, 16, FieldMode.Write,
+                        writeCallback: (_, val) => { if(val != 0) WriteOutputState((ushort)(BitHelper.GetValueFromBitsArray(outputLatch) | val)); },
+                        name: "GPIOx_BS")
                 },
                 { (long)Registers.ConfigurationLock, new DoubleWordRegister(this)
                     .WithValueField(0, 16, out var pendingLockPins, name: "LCK",

--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/STM32_GPIOPort.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/STM32_GPIOPort.cs
@@ -61,6 +61,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
             mode = new Mode[NumberOfPins];
             outputSpeed = new OutputSpeed[NumberOfPins];
             pullUpPullDown = new PullUpPullDown[NumberOfPins];
+            outputLatch = new bool[NumberOfPins];
 
             this.modeResetValue = modeResetValue;
             this.outputSpeedResetValue = outputSpeedResetValue;
@@ -84,6 +85,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
 
             lockedPins = 0;
             lockSequenceState = LockSequence.Idle;
+            Array.Clear(outputLatch, 0, outputLatch.Length);
 
             for(var i = 0; i < NumberOfPins; i++)
             {
@@ -127,12 +129,21 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
             Connections[number].Set(value);
         }
 
-        private void WriteState(ushort value)
+        private void WriteOutputPin(int number, bool value)
+        {
+            outputLatch[number] = value;
+            if(mode[number] == Mode.Output)
+            {
+                WritePin(number, value);
+            }
+        }
+
+        private void WriteOutputState(ushort value)
         {
             for(var i = 0; i < NumberOfPins; i++)
             {
                 var state = ((value & 1u) == 1);
-                WritePin(i, state);
+                WriteOutputPin(i, state);
 
                 value >>= 1;
             }
@@ -142,6 +153,10 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
         {
             mode[number] = newMode;
             alternateFunctionOutputs[number].IsConnected = newMode == Mode.AlternateFunction;
+            if(newMode == Mode.Output)
+            {
+                WritePin(number, outputLatch[number]);
+            }
         }
 
         private void GuardPinAction(int number, string name, Action action)
@@ -197,15 +212,15 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     .WithReservedBits(16, 16)
                 },
                 {(long)Registers.OutputData, new DoubleWordRegister(this)
-                    .WithValueField(0, 16, writeCallback: (_, val) => WriteState((ushort)val), valueProviderCallback: _ => BitHelper.GetValueFromBitsArray(State), name: "ODR")
+                    .WithValueField(0, 16, writeCallback: (_, val) => WriteOutputState((ushort)val), valueProviderCallback: _ => BitHelper.GetValueFromBitsArray(outputLatch), name: "ODR")
                     .WithReservedBits(16, 16)
                 },
                 {(long)Registers.BitSet, new DoubleWordRegister(this)
                     .WithValueField(0, 16, FieldMode.Write,
-                        writeCallback: (_, val) => { if(val != 0) WriteState((ushort)(BitHelper.GetValueFromBitsArray(State) | val)); },
+                        writeCallback: (_, val) => { if(val != 0) WriteOutputState((ushort)(BitHelper.GetValueFromBitsArray(outputLatch) | val)); },
                         name: "GPIOx_BS")
                     .WithValueField(16, 16, FieldMode.Write,
-                        writeCallback: (_, val) => { if(val != 0) WriteState((ushort)(BitHelper.GetValueFromBitsArray(State) & ~val)); },
+                        writeCallback: (_, val) => { if(val != 0) WriteOutputState((ushort)(BitHelper.GetValueFromBitsArray(outputLatch) & ~val)); },
                         name: "GPIOx_BR")
                 },
                 { (long)Registers.ConfigurationLock, new DoubleWordRegister(this)
@@ -278,7 +293,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 },
                 {(long)Registers.BitReset, new DoubleWordRegister(this)
                     .WithValueField(0, 16, FieldMode.Write,
-                        writeCallback: (_, val) => { if(val != 0) WriteState((ushort)(BitHelper.GetValueFromBitsArray(State) & ~val)); },
+                        writeCallback: (_, val) => { if(val != 0) WriteOutputState((ushort)(BitHelper.GetValueFromBitsArray(outputLatch) & ~val)); },
                         name: "GPIOx_BRR")
                     .WithReservedBits(16, 16)
                 },
@@ -292,6 +307,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
         private readonly Mode[] mode;
         private readonly OutputSpeed[] outputSpeed;
         private readonly PullUpPullDown[] pullUpPullDown;
+        private readonly bool[] outputLatch;
         private readonly HashSet<InvertedAFPin> invertedAFPins = new HashSet<InvertedAFPin>();
 
         private readonly uint modeResetValue;

--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/STM32_GPIOPort.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/STM32_GPIOPort.cs
@@ -149,6 +149,24 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
             }
         }
 
+        private void WriteBitSetReset(uint value)
+        {
+            var setMask = value & 0xFFFF;
+            var resetMask = value >> 16;
+            for(var i = 0; i < NumberOfPins; i++)
+            {
+                var pinMask = 1u << i;
+                if((setMask & pinMask) != 0)
+                {
+                    WriteOutputPin(i, true);
+                }
+                else if((resetMask & pinMask) != 0)
+                {
+                    WriteOutputPin(i, false);
+                }
+            }
+        }
+
         private void ChangeMode(int number, Mode newMode)
         {
             mode[number] = newMode;
@@ -216,12 +234,11 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     .WithReservedBits(16, 16)
                 },
                 {(long)Registers.BitSet, new DoubleWordRegister(this)
-                    .WithValueField(0, 16, FieldMode.Write,
-                        writeCallback: (_, val) => { if(val != 0) WriteOutputState((ushort)(BitHelper.GetValueFromBitsArray(outputLatch) | val)); },
-                        name: "GPIOx_BS")
                     .WithValueField(16, 16, FieldMode.Write,
-                        writeCallback: (_, val) => { if(val != 0) WriteOutputState((ushort)(BitHelper.GetValueFromBitsArray(outputLatch) & ~val)); },
                         name: "GPIOx_BR")
+                    .WithValueField(0, 16, FieldMode.Write,
+                        name: "GPIOx_BS")
+                    .WithWriteCallback((_, value) => WriteBitSetReset(value))
                 },
                 { (long)Registers.ConfigurationLock, new DoubleWordRegister(this)
                     .WithValueField(0, 16, out var pendingLockPins, name: "LCK",

--- a/src/Emulator/Peripherals/Test/PeripheralsTests/STM32_GPIOPortTests.cs
+++ b/src/Emulator/Peripherals/Test/PeripheralsTests/STM32_GPIOPortTests.cs
@@ -1,0 +1,114 @@
+//
+// Copyright (c) 2026 John Elliott
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Peripherals.GPIOPort;
+
+using NUnit.Framework;
+
+namespace Antmicro.Renode.UnitTests
+{
+    [TestFixture]
+    public class STM32_GPIOPortTests
+    {
+        [Test]
+        public void ShouldKeepInputAndOutputDataIndependentInInputMode()
+        {
+            using(var machine = new Machine())
+            {
+                var gpio = new STM32_GPIOPort(machine);
+
+                gpio.WriteDoubleWord(OutputData, 1u << Pin);
+
+                Assert.That(gpio.ReadDoubleWord(OutputData), Is.EqualTo(1u << Pin));
+                Assert.That(gpio.ReadDoubleWord(InputData), Is.Zero);
+
+                gpio.OnGPIO(Pin, true);
+
+                Assert.That(gpio.ReadDoubleWord(InputData), Is.EqualTo(1u << Pin));
+                Assert.That(gpio.ReadDoubleWord(OutputData), Is.EqualTo(1u << Pin));
+            }
+        }
+
+        [TestCase(InputMode)]
+        [TestCase(AlternateFunctionMode)]
+        [TestCase(AnalogMode)]
+        public void ShouldOnlyDriveLatchedValueInOutputMode(uint initialMode)
+        {
+            using(var machine = new Machine())
+            {
+                var gpio = new STM32_GPIOPort(machine);
+
+                gpio.WriteDoubleWord(Mode, initialMode << (Pin * 2));
+                gpio.WriteDoubleWord(OutputData, 1u << Pin);
+
+                Assert.That(gpio.ReadDoubleWord(OutputData), Is.EqualTo(1u << Pin));
+                Assert.That(gpio.ReadDoubleWord(InputData), Is.Zero);
+                Assert.That(gpio.Connections[Pin].IsSet, Is.False);
+
+                gpio.WriteDoubleWord(Mode, OutputMode << (Pin * 2));
+
+                Assert.That(gpio.ReadDoubleWord(InputData), Is.EqualTo(1u << Pin));
+                Assert.That(gpio.Connections[Pin].IsSet, Is.True);
+            }
+        }
+
+        [Test]
+        public void ShouldUpdateOutputLatchThroughSetAndResetRegisters()
+        {
+            using(var machine = new Machine())
+            {
+                var gpio = new STM32_GPIOPort(machine);
+
+                gpio.OnGPIO(Pin, true);
+                gpio.WriteDoubleWord(BitSetReset, 1u << Pin);
+
+                Assert.That(gpio.ReadDoubleWord(OutputData), Is.EqualTo(1u << Pin));
+                Assert.That(gpio.ReadDoubleWord(InputData), Is.EqualTo(1u << Pin));
+
+                gpio.WriteDoubleWord(BitSetReset, 1u << (Pin + 16));
+
+                Assert.That(gpio.ReadDoubleWord(OutputData), Is.Zero);
+                Assert.That(gpio.ReadDoubleWord(InputData), Is.EqualTo(1u << Pin));
+
+                gpio.WriteDoubleWord(OutputData, 1u << Pin);
+                gpio.WriteDoubleWord(BitReset, 1u << Pin);
+
+                Assert.That(gpio.ReadDoubleWord(OutputData), Is.Zero);
+                Assert.That(gpio.ReadDoubleWord(InputData), Is.EqualTo(1u << Pin));
+            }
+        }
+
+        [Test]
+        public void ShouldClearOutputLatchOnReset()
+        {
+            using(var machine = new Machine())
+            {
+                var gpio = new STM32_GPIOPort(machine);
+
+                gpio.WriteDoubleWord(Mode, OutputMode << (Pin * 2));
+                gpio.WriteDoubleWord(OutputData, 1u << Pin);
+                gpio.Reset();
+
+                Assert.That(gpio.ReadDoubleWord(OutputData), Is.Zero);
+                Assert.That(gpio.ReadDoubleWord(InputData), Is.Zero);
+                Assert.That(gpio.Connections[Pin].IsSet, Is.False);
+            }
+        }
+
+        private const int Pin = 2;
+        private const uint InputMode = 0;
+        private const uint OutputMode = 1;
+        private const uint AlternateFunctionMode = 2;
+        private const uint AnalogMode = 3;
+        private const long Mode = 0x00;
+        private const long InputData = 0x10;
+        private const long OutputData = 0x14;
+        private const long BitSetReset = 0x18;
+        private const long BitReset = 0x28;
+    }
+}

--- a/src/Emulator/Peripherals/Test/PeripheralsTests/STM32_GPIOPortTests.cs
+++ b/src/Emulator/Peripherals/Test/PeripheralsTests/STM32_GPIOPortTests.cs
@@ -84,6 +84,19 @@ namespace Antmicro.Renode.UnitTests
         }
 
         [Test]
+        public void ShouldPrioritizeSetWhenBitSetAndResetAreWrittenTogether()
+        {
+            using(var machine = new Machine())
+            {
+                var gpio = new STM32_GPIOPort(machine);
+
+                gpio.WriteDoubleWord(BitSetReset, (1u << Pin) | (1u << (Pin + 16)));
+
+                Assert.That(gpio.ReadDoubleWord(OutputData), Is.EqualTo(1u << Pin));
+            }
+        }
+
+        [Test]
         public void ShouldClearOutputLatchOnReset()
         {
             using(var machine = new Machine())

--- a/src/Emulator/Peripherals/Test/PeripheralsTests/STM32_GPIOPortTests.cs
+++ b/src/Emulator/Peripherals/Test/PeripheralsTests/STM32_GPIOPortTests.cs
@@ -84,6 +84,62 @@ namespace Antmicro.Renode.UnitTests
         }
 
         [Test]
+        public void ShouldPrioritizeSetWhenBitSetAndResetAreWrittenTogether()
+        {
+            using(var machine = new Machine())
+            {
+                var gpio = new STM32_GPIOPort(machine);
+
+                gpio.WriteDoubleWord(BitSetReset, (1u << Pin) | (1u << (Pin + 16)));
+
+                Assert.That(gpio.ReadDoubleWord(OutputData), Is.EqualTo(1u << Pin));
+            }
+        }
+
+        [Test]
+        public void ShouldNotPulseOutputWhenBitSetAndResetAreWrittenTogether()
+        {
+            using(var machine = new Machine())
+            {
+                var gpio = new STM32_GPIOPort(machine);
+                gpio.WriteDoubleWord(Mode, OutputMode << (Pin * 2));
+                gpio.WriteDoubleWord(OutputData, 1u << Pin);
+
+                var transitionCount = 0;
+                ((IGPIOWithHooks)gpio.Connections[Pin]).AddStateChangedHook(_ => transitionCount++);
+
+                gpio.WriteDoubleWord(BitSetReset, (1u << Pin) | (1u << (Pin + 16)));
+
+                Assert.That(gpio.ReadDoubleWord(OutputData), Is.EqualTo(1u << Pin));
+                Assert.That(gpio.ReadDoubleWord(InputData), Is.EqualTo(1u << Pin));
+                Assert.That(gpio.Connections[Pin].IsSet, Is.True);
+                Assert.That(transitionCount, Is.Zero);
+            }
+        }
+
+        [Test]
+        public void ShouldNotRedriveUnrelatedPinsOnBitSetResetWrite()
+        {
+            using(var machine = new Machine())
+            {
+                var gpio = new STM32_GPIOPort(machine);
+                gpio.WriteDoubleWord(Mode, OutputMode << (Pin * 2));
+                gpio.WriteDoubleWord(OutputData, 1u << Pin);
+                gpio.OnGPIO(Pin, false);
+
+                var transitionCount = 0;
+                ((IGPIOWithHooks)gpio.Connections[Pin]).AddStateChangedHook(_ => transitionCount++);
+
+                gpio.WriteDoubleWord(BitSetReset, 1u << OtherPin);
+
+                Assert.That(gpio.ReadDoubleWord(OutputData), Is.EqualTo((1u << Pin) | (1u << OtherPin)));
+                Assert.That(gpio.ReadDoubleWord(InputData), Is.Zero);
+                Assert.That(gpio.Connections[Pin].IsSet, Is.False);
+                Assert.That(transitionCount, Is.Zero);
+            }
+        }
+
+        [Test]
         public void ShouldClearOutputLatchOnReset()
         {
             using(var machine = new Machine())
@@ -101,6 +157,7 @@ namespace Antmicro.Renode.UnitTests
         }
 
         private const int Pin = 2;
+        private const int OtherPin = 3;
         private const uint InputMode = 0;
         private const uint OutputMode = 1;
         private const uint AlternateFunctionMode = 2;


### PR DESCRIPTION
### Related issue

Fixes renode/renode#942

### Description

Separates the STM32 GPIO output latch from the electrical/input pin state.

ODR, BSRR, and BRR update a dedicated 16-bit latch. Only output-mode pins drive that value onto their GPIO connection, and switching a pin to output mode applies its existing latched value. Reset clears both the pin state and the output latch.

BSRR uses one register-level callback. Set bits take priority over reset bits on overlap, each affected pin is written at most once, and unrelated pins remain untouched. This prevents a transient output pulse and preserves electrical state on unrelated writes.

Regression tests cover input/ODR independence, input/alternate-function/analog non-driving behavior, switching to output mode, BSRR, BRR, reset, set-over-reset priority, transient-pulse suppression, and unrelated-pin isolation.

### Usage example

The reproduction in renode/renode#942 reads IDR as zero after latching ODR bit 2, while ODR reads back bit 2. Writing both BSRR halves for bit 2 leaves the ODR bit set.

### Additional information

Rebased onto current master and validated on macOS Arm64 with .NET 8:

- focused STM32 GPIO tests: 9 passed, 0 failed
- full headless Release build: succeeded with 0 errors and one pre-existing warning
- full managed solution: 1,121 passed, 17 existing skips, 0 failures
- scoped `dotnet format --verify-no-changes` on both changed files: passed
- STM32F072B Robot suite: 6 passed, 0 failed
- STM32F4 Discovery Robot suite: 13 passed, 0 failed
- issue #942 monitor reproduction: IDR `0x00000000`, ODR `0x00000004`, post-BSRR ODR `0x00000004`
