### PR TITLE
mcan: fix rx buffer filtering

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/CAN/MCAN.cs
+++ b/src/Emulator/Peripherals/Peripherals/CAN/MCAN.cs
@@ -893,7 +893,14 @@ namespace Antmicro.Renode.Peripherals.CAN
                         }
                     }
 
-                    match = MatchFilterElement(isExtended, id, filter);
+                    // M_CAN: a filter element set to "store into Rx Buffer or as a debug
+                    // message" (SFEC/EFEC == 7) ignores the SFT/EFT filter-type field and
+                    // matches the dedicated ID in ID1 (SFID1/EFID1). ID2 (SFID2/EFID2) holds
+                    // the target Rx Buffer index in this mode, not a second ID, so it must
+                    // not be handed to the range/dual/classic matcher.
+                    match = filter.FilterElementConfiguration == FilterElementConfiguration.RxBufferOrDebugMessageOnMatch
+                        ? id == filter.ID1
+                        : MatchFilterElement(isExtended, id, filter);
 
                     if(!match)
                     {

--- a/src/Emulator/Peripherals/Peripherals/CAN/MCAN.cs
+++ b/src/Emulator/Peripherals/Peripherals/CAN/MCAN.cs
@@ -898,8 +898,14 @@ namespace Antmicro.Renode.Peripherals.CAN
                     // matches the dedicated ID in ID1 (SFID1/EFID1). ID2 (SFID2/EFID2) holds
                     // the target Rx Buffer index in this mode, not a second ID, so it must
                     // not be handed to the range/dual/classic matcher.
+                    // For extended frames, the received ID is ANDed with the Extended ID
+                    // AND Mask (XIDAM) before the comparison, as acceptance filtering of
+                    // extended frames is always performed on the masked ID.
+                    var effectiveId = isExtended
+                        ? id & (uint)rv.ExtendedIdANDMask.ExtendedIDANDMask.Value
+                        : id;
                     match = filter.FilterElementConfiguration == FilterElementConfiguration.RxBufferOrDebugMessageOnMatch
-                        ? id == filter.ID1
+                        ? effectiveId == filter.ID1
                         : MatchFilterElement(isExtended, id, filter);
 
                     if(!match)


### PR DESCRIPTION
We faced an issue while working with SAMV71 MCAN : RX worked fine with FIFOs, but not with buffers, while the same code worked on the actual SAMV71 hardware.

This commit fixes that by implementing the same behavior as it does on the hardware.

We get the same behavior on hardware and emulated with this fix.