### PR TITLE
Feature — adds first-class STM32H5 peripheral models

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/Cache/STM32H5_ICACHE.cs
+++ b/src/Emulator/Peripherals/Peripherals/Cache/STM32H5_ICACHE.cs
@@ -1,0 +1,149 @@
+//
+// Copyright (c) 2010-2025 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+
+// Known limitation, deliberate for this version:
+// This models the ICACHE register interface over a no-op cache. HMONR/MMONR always read 0
+// and must not be read as a measurement; CACHEINV completes in zero emulated time so BUSYF
+// is never observable as set.
+//
+// Future work: line-level cache storage with access-driven hit and miss counters, and
+// invalidation that occupies emulated time so BUSYF is observable.
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Peripherals.Bus;
+
+namespace Antmicro.Renode.Peripherals.Cache
+{
+    [AllowedTranslations(AllowedTranslation.ByteToDoubleWord | AllowedTranslation.WordToDoubleWord)]
+    public sealed class STM32H5_ICACHE : BasicDoubleWordPeripheral, IKnownSize
+    {
+        public STM32H5_ICACHE(IMachine machine) : base(machine)
+        {
+            DefineRegisters();
+            Reset();
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            bsyendf = false;
+            errf = false;
+        }
+
+        public long Size => 0x400;
+
+        private void DefineRegisters()
+        {
+            Registers.Control.Define(this)
+                .WithFlag(0, name: "EN")
+                .WithFlag(1, FieldMode.Write, name: "CACHEINV",
+                    writeCallback: (_, val) =>
+                    {
+                        if(val)
+                        {
+                            // Invalidation completes instantly in a no-op cache.
+                            bsyendf = true;
+                        }
+                    })
+                .WithFlag(2, name: "WAYSEL")
+                .WithReservedBits(3, 13)
+                .WithFlag(16, name: "HITMEN")
+                .WithFlag(17, name: "MISSMEN")
+                .WithFlag(18, FieldMode.Write, name: "HITMRST",
+                    writeCallback: (_, val) =>
+                    {
+                        if(val)
+                        {
+                            hitMonitor.Value = 0;
+                        }
+                    })
+                .WithFlag(19, FieldMode.Write, name: "MISSMRST",
+                    writeCallback: (_, val) =>
+                    {
+                        if(val)
+                        {
+                            missMonitor.Value = 0;
+                        }
+                    })
+                .WithReservedBits(20, 12);
+
+            Registers.Status.Define(this)
+                .WithFlag(0, FieldMode.Read, name: "BUSYF",
+                    valueProviderCallback: _ => false)
+                .WithFlag(1, FieldMode.Read, name: "BSYENDF",
+                    valueProviderCallback: _ => bsyendf)
+                .WithFlag(2, FieldMode.Read, name: "ERRF",
+                    valueProviderCallback: _ => errf)
+                .WithReservedBits(3, 29);
+
+            Registers.InterruptEnable.Define(this)
+                .WithReservedBits(0, 1)
+                .WithFlag(1, name: "BSYENDIE")
+                .WithFlag(2, name: "ERRIE")
+                .WithReservedBits(3, 29);
+
+            Registers.FlagClear.Define(this, name: "ICACHE_FCR")
+                .WithReservedBits(0, 1)
+                .WithFlag(1, FieldMode.Write, name: "CBSYENDF",
+                    writeCallback: (_, val) =>
+                    {
+                        if(val)
+                        {
+                            bsyendf = false;
+                        }
+                    })
+                .WithFlag(2, FieldMode.Write, name: "CERRF",
+                    writeCallback: (_, val) =>
+                    {
+                        if(val)
+                        {
+                            errf = false;
+                        }
+                    })
+                .WithReservedBits(3, 29);
+
+            Registers.HitMonitor.Define(this)
+                .WithValueField(0, 32, out hitMonitor, FieldMode.Read, name: "HITMON");
+
+            Registers.MissMonitor.Define(this)
+                .WithValueField(0, 32, out missMonitor, FieldMode.Read, name: "MISSMON");
+
+            Registers.RegionConfiguration0.Define(this)
+                .WithTag("CRR0", 0, 32);
+
+            Registers.RegionConfiguration1.Define(this)
+                .WithTag("CRR1", 0, 32);
+
+            Registers.RegionConfiguration2.Define(this)
+                .WithTag("CRR2", 0, 32);
+
+            Registers.RegionConfiguration3.Define(this)
+                .WithTag("CRR3", 0, 32);
+        }
+
+        private IValueRegisterField hitMonitor;
+        private IValueRegisterField missMonitor;
+        private bool bsyendf;
+        private bool errf;
+
+        private enum Registers
+        {
+            Control = 0x00,
+            Status = 0x04,
+            InterruptEnable = 0x08,
+            FlagClear = 0x0C,
+            HitMonitor = 0x10,
+            MissMonitor = 0x14,
+            // 0x18-0x1C reserved
+            RegionConfiguration0 = 0x20,
+            RegionConfiguration1 = 0x24,
+            RegionConfiguration2 = 0x28,
+            RegionConfiguration3 = 0x2C,
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/IRQControllers/STM32H5_EXTI.cs
+++ b/src/Emulator/Peripherals/Peripherals/IRQControllers/STM32H5_EXTI.cs
@@ -1,0 +1,384 @@
+//
+// Copyright (c) 2010-2026 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+using Antmicro.Renode.Utilities;
+
+namespace Antmicro.Renode.Peripherals.IRQControllers
+{
+    // The H5 EXTI layout is neither the WBA layout (single bank, IMR1 at 0x80 with no fields)
+    // nor the H7 layout (3 banks, pending at 0x88/0x98/0xA8). The H5 has:
+    //   - Bank stride 0x20 for the trigger/pending group (0x00..0x18 / 0x20..0x38)
+    //   - Bank stride 0x10 for the mask group, sitting at 0x80/0x90
+    //   - Separate rising/falling pending registers (RPR/FPR) with write-1-to-clear
+    //   - EXTICR mux registers at 0x60..0x6C (same as WBA)
+    //
+    // IMR1/IMR2 are defined WITH fields (out core.InterruptMask), unlike STM32WBA_EXTI which
+    // defines IMR1 with no fields — that drops the mask and leaves core.InterruptMask null
+    // while SWIER1's callback dereferences it.
+    [AllowedTranslations(AllowedTranslation.ByteToDoubleWord | AllowedTranslation.WordToDoubleWord)]
+    public class STM32H5_EXTI : BasicDoubleWordPeripheral, IKnownSize, IIRQController, ILocalGPIOReceiver, INumberedGPIOOutput
+    {
+        public STM32H5_EXTI(IMachine machine, int numberOfOutputLines = DefaultNumberOfLines) : base(machine)
+        {
+            cores = new STM32_EXTICore[BankCount];
+            for(var i = 0; i < BankCount; i++)
+            {
+                cores[i] = new STM32_EXTICore(this, LineConfigurations[i], separateConfigs: true);
+            }
+
+            var innerConnections = new Dictionary<int, IGPIO>();
+            for(var i = 0; i < numberOfOutputLines; i++)
+            {
+                innerConnections[i] = new GPIO();
+            }
+            Connections = new ReadOnlyDictionary<int, IGPIO>(innerConnections);
+            internalReceiversCache = new Dictionary<int, InternalReceiver>();
+
+            DefineRegisters();
+            Reset();
+        }
+
+        public IGPIOReceiver GetLocalReceiver(int index)
+        {
+            if(!internalReceiversCache.TryGetValue(index, out var receiver))
+            {
+                receiver = new InternalReceiver(this, index);
+                internalReceiversCache.Add(index, receiver);
+            }
+            return receiver;
+        }
+
+        public void OnGPIO(int number, bool value)
+        {
+            if(number < 0 || number >= Connections.Count)
+            {
+                this.Log(LogLevel.Error, "GPIO number {0} is out of range [0; {1})", number, Connections.Count);
+                return;
+            }
+
+            var coreIndex = number / LinesPerCore;
+            var localLine = (byte)(number % LinesPerCore);
+            var core = cores[coreIndex];
+
+            if(core.CanSetInterruptValue(localLine, value, out var _))
+            {
+                // H5 edge detection: determine edge direction from the transition value itself
+                // (true = rising edge, false = falling edge) and set RPR/FPR directly.
+                //
+                // We bypass STM32_EXTICore.UpdatePendingValue because its separateConfigs path
+                // uses `isRaising = (value != true)`, which inverts the caller's boolean — passing
+                // `true` lands in PendingFallingInterrupts.  WBA works around this by always passing
+                // `true`, which puts every event in the raising register.  H5's HAL_EXTI_IRQHandler
+                // reads RPR1 and FPR1 separately to dispatch callbacks, so the distinction is
+                // observable and must be correct.
+                //
+                // The pending bit is set regardless of the interrupt mask (RPR/FPR record the edge);
+                // the output (Connections[line]) is only asserted when IMR gates delivery.
+                SetPendingBit(core, localLine, isRising: value);
+                if(BitHelper.IsBitSet(core.InterruptMask.Value, localLine))
+                {
+                    Connections[number].Set(true);
+                }
+            }
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            foreach(var connection in Connections.Values)
+            {
+                connection.Unset();
+            }
+            foreach(var receiver in internalReceiversCache.Values)
+            {
+                for(var pin = 0; pin < GpioPins; pin++)
+                {
+                    receiver.UpdateGPIO(pin);
+                }
+            }
+        }
+
+        public long Size => 0x400;
+
+        public IReadOnlyDictionary<int, IGPIO> Connections { get; }
+
+        private void DefineRegisters()
+        {
+            // Bank 1 (lines 0-31): trigger/pending group at 0x00..0x18
+            RegistersCollection.DefineRegister((long)Registers.RisingTriggerSelection1)
+                .WithValueField(0, 17, out cores[0].RisingEdgeMask, name: "RT")
+                .WithReservedBits(17, 15);
+
+            RegistersCollection.DefineRegister((long)Registers.FallingTriggerSelection1)
+                .WithValueField(0, 17, out cores[0].FallingEdgeMask, name: "FT")
+                .WithReservedBits(17, 15);
+
+            RegistersCollection.DefineRegister((long)Registers.SoftwareInterruptEvent1)
+                .WithValueField(0, 32, name: "SWIER1", writeCallback: (_, value) =>
+                {
+                    BitHelper.ForeachActiveBit(value & cores[0].InterruptMask.Value, bit =>
+                    {
+                        // SWIER always simulates a rising edge (sets RPR)
+                        SetPendingBit(cores[0], (byte)bit, isRising: true);
+                        Connections[bit].Set();
+                    });
+                });
+
+            RegistersCollection.DefineRegister((long)Registers.RisingPending1)
+                .WithValueField(0, 32, out cores[0].PendingRaisingInterrupts,
+                    FieldMode.Read | FieldMode.WriteOneToClear,
+                    writeCallback: (_, val) => BitHelper.ForeachActiveBit(val, x => Connections[x].Unset()),
+                    name: "RPIF1");
+
+            RegistersCollection.DefineRegister((long)Registers.FallingPending1)
+                .WithValueField(0, 32, out cores[0].PendingFallingInterrupts,
+                    FieldMode.Read | FieldMode.WriteOneToClear,
+                    writeCallback: (_, val) => BitHelper.ForeachActiveBit(val, x => Connections[x].Unset()),
+                    name: "FPIF1");
+
+            RegistersCollection.DefineRegister((long)Registers.SecurityConfiguration1)
+                .WithValueField(0, 32, name: "SEC1");
+
+            RegistersCollection.DefineRegister((long)Registers.PrivilegeConfiguration1)
+                .WithValueField(0, 32, name: "PRIV1");
+
+            // Bank 2 (lines 32-58): trigger/pending group at 0x20..0x38
+            RegistersCollection.DefineRegister((long)Registers.RisingTriggerSelection2)
+                .WithValueField(0, 27, out cores[1].RisingEdgeMask, name: "RT")
+                .WithReservedBits(27, 5);
+
+            RegistersCollection.DefineRegister((long)Registers.FallingTriggerSelection2)
+                .WithValueField(0, 27, out cores[1].FallingEdgeMask, name: "FT")
+                .WithReservedBits(27, 5);
+
+            RegistersCollection.DefineRegister((long)Registers.SoftwareInterruptEvent2)
+                .WithValueField(0, 27, name: "SWIER2", writeCallback: (_, value) =>
+                {
+                    BitHelper.ForeachActiveBit(value & cores[1].InterruptMask.Value, bit =>
+                    {
+                        var globalLine = LinesPerCore + bit;
+                        // SWIER always simulates a rising edge (sets RPR)
+                        SetPendingBit(cores[1], (byte)bit, isRising: true);
+                        if(Connections.TryGetValue(globalLine, out var irq))
+                        {
+                            irq.Set();
+                        }
+                    });
+                })
+                .WithReservedBits(27, 5);
+
+            RegistersCollection.DefineRegister((long)Registers.RisingPending2)
+                .WithValueField(0, 27, out cores[1].PendingRaisingInterrupts,
+                    FieldMode.Read | FieldMode.WriteOneToClear,
+                    writeCallback: (_, val) => BitHelper.ForeachActiveBit(val, x =>
+                    {
+                        var globalLine = LinesPerCore + x;
+                        if(Connections.TryGetValue(globalLine, out var irq))
+                        {
+                            irq.Unset();
+                        }
+                    }),
+                    name: "RPIF2")
+                .WithReservedBits(27, 5);
+
+            RegistersCollection.DefineRegister((long)Registers.FallingPending2)
+                .WithValueField(0, 27, out cores[1].PendingFallingInterrupts,
+                    FieldMode.Read | FieldMode.WriteOneToClear,
+                    writeCallback: (_, val) => BitHelper.ForeachActiveBit(val, x =>
+                    {
+                        var globalLine = LinesPerCore + x;
+                        if(Connections.TryGetValue(globalLine, out var irq))
+                        {
+                            irq.Unset();
+                        }
+                    }),
+                    name: "FPIF2")
+                .WithReservedBits(27, 5);
+
+            RegistersCollection.DefineRegister((long)Registers.SecurityConfiguration2)
+                .WithValueField(0, 27, name: "SEC2")
+                .WithReservedBits(27, 5);
+
+            RegistersCollection.DefineRegister((long)Registers.PrivilegeConfiguration2)
+                .WithValueField(0, 27, name: "PRIV2")
+                .WithReservedBits(27, 5);
+
+            // EXTICR[4] at 0x60..0x6C — external interrupt configuration (port mux for lines 0-15)
+            for(var registerIndex = 0; registerIndex < InterruptSelectionRegistersCount; registerIndex++)
+            {
+                var reg = new DoubleWordRegister(this, 0);
+                for(var fieldNumber = 0; fieldNumber < NumberOfPortsPerInterruptSelectionRegister; fieldNumber++)
+                {
+                    var pinNumber = registerIndex * NumberOfPortsPerInterruptSelectionRegister + fieldNumber;
+                    extiMappings[pinNumber] = reg.DefineValueField(8 * fieldNumber, 8, name: $"EXTI{pinNumber}",
+                        changeCallback: (_, portNumber) =>
+                        {
+                            Connections[pinNumber].Unset();
+                            ((InternalReceiver)GetLocalReceiver((int)portNumber)).UpdateGPIO(pinNumber);
+                        }
+                    );
+                }
+                RegistersCollection.AddRegister((long)Registers.ExternalInterruptSelection1 + 4 * registerIndex, reg);
+            }
+
+            // LOCKR at 0x70
+            RegistersCollection.DefineRegister((long)Registers.Lock)
+                .WithFlag(0, name: "LOCKR")
+                .WithReservedBits(1, 31);
+
+            // IMR1 at 0x80 — interrupt mask, bank 1 (32 bits: lines 0-31)
+            // Defined WITH fields so that core.InterruptMask is non-null and SWIER1 can dereference it
+            RegistersCollection.DefineRegister((long)Registers.InterruptMask1, resetValue: 0xFFF80000)
+                .WithValueField(0, 32, out cores[0].InterruptMask, name: "IM1");
+
+            // EMR1 at 0x84 — event mask, bank 1 (32 bits: lines 0-31)
+            RegistersCollection.DefineRegister((long)Registers.EventMask1)
+                .WithValueField(0, 32, name: "EM1");
+
+            // IMR2 at 0x90 — interrupt mask, bank 2 (26 bits: lines 32-57)
+            RegistersCollection.DefineRegister((long)Registers.InterruptMask2, resetValue: 0x03FFFFFF)
+                .WithValueField(0, 26, out cores[1].InterruptMask, name: "IM2")
+                .WithReservedBits(26, 6);
+
+            // EMR2 at 0x94 — event mask, bank 2 (26 bits: lines 32-57)
+            RegistersCollection.DefineRegister((long)Registers.EventMask2)
+                .WithValueField(0, 26, name: "EM2")
+                .WithReservedBits(26, 6);
+        }
+
+        private readonly STM32_EXTICore[] cores;
+        private readonly Dictionary<int, InternalReceiver> internalReceiversCache;
+        private readonly IValueRegisterField[] extiMappings = new IValueRegisterField[GpioPins];
+
+        /// <summary>
+        /// Sets the correct pending register (RPR for rising, FPR for falling) directly,
+        /// bypassing STM32_EXTICore.UpdatePendingValue whose separateConfigs path inverts
+        /// the boolean.
+        /// </summary>
+        private static void SetPendingBit(STM32_EXTICore core, byte bit, bool isRising)
+        {
+            var field = isRising ? core.PendingRaisingInterrupts : core.PendingFallingInterrupts;
+            var reg = field.Value;
+            BitHelper.SetBit(ref reg, bit, true);
+            field.Value = reg;
+        }
+
+        // Bank 1: lines 0-15 are EXTI_GPIO (configurable), line 16 is EXTI_CONFIG (configurable),
+        //   lines 17-31 are EXTI_DIRECT — from stm32h5xx_hal_exti.h EXTI_LINE property table
+        // Bank 2: resolved from stm32h5xx_hal_exti.h for STM32H563xx (RM0481 Rev 3, Table 145
+        //   "EXTI lines connections"). For H563 the defined peripherals give:
+        //     Line 46 (bit 14) = EXTI_CONFIG — ETH wakeup (#if defined(ETH), true for H563)
+        //     Line 49 (bit 17) = EXTI_DIRECT — not H5E5/H5E4/H5F5/H5F4
+        //     Line 50 (bit 18) = EXTI_CONFIG — unconditional
+        //     Line 53 (bit 21) = EXTI_CONFIG — unconditional
+        //   All other bank-2 lines (32-45, 47-49, 51-52, 54-57) are EXTI_DIRECT.
+        //   Line 58 (COMP1/I3C2) is not present on H563 (neither COMP1 nor I3C2 defined).
+        //   Resolved-from-documentation: unobservable in the reference firmware (no bank-2
+        //   configurable sources are modelled), verified against HAL defines only.
+        private static readonly ulong[] LineConfigurations = new ulong[BankCount]
+        {
+            0x0001FFFF, // Bank 1: bits [0:16] configurable (GPIO + EXTI_CONFIG line 16)
+            0x00244000, // Bank 2: bits 14, 18, 21 configurable (lines 46, 50, 53)
+        };
+
+        private const int BankCount = 2;
+        private const int LinesPerCore = 32;
+        private const int DefaultNumberOfLines = 59;
+        private const int GpioPins = 16;
+        private const uint InterruptSelectionRegistersCount = 4;
+        private const int NumberOfPortsPerInterruptSelectionRegister = GpioPins / (int)InterruptSelectionRegistersCount;
+
+        private class InternalReceiver : IGPIOReceiver
+        {
+            public InternalReceiver(STM32H5_EXTI parent, int portNumber)
+            {
+                this.parent = parent;
+                this.portNumber = portNumber;
+                this.state = new bool[GpioPins];
+            }
+
+            public void OnGPIO(int pinNumber, bool value)
+            {
+                if(pinNumber >= GpioPins)
+                {
+                    parent.Log(LogLevel.Error, "GPIO port {0}, pin {1}, is not supported. Up to {2} pins are supported", portNumber, pinNumber, GpioPins);
+                    return;
+                }
+                parent.Log(LogLevel.Noisy, "GPIO port {0}, pin {1}, raised IRQ: {2}", portNumber, pinNumber, value);
+                state[pinNumber] = value;
+
+                UpdateGPIO(pinNumber);
+            }
+
+            public void UpdateGPIO(int pinNumber)
+            {
+                if((int)parent.extiMappings[pinNumber].Value == portNumber)
+                {
+                    var value = state[pinNumber];
+                    if(parent.cores[0].CanSetInterruptValue((byte)pinNumber, value, out var _))
+                    {
+                        // See OnGPIO for the rationale: set RPR/FPR from the edge direction,
+                        // gate the output on InterruptMask.
+                        SetPendingBit(parent.cores[0], (byte)pinNumber, isRising: value);
+                        if(BitHelper.IsBitSet(parent.cores[0].InterruptMask.Value, (byte)pinNumber))
+                        {
+                            parent.Connections[pinNumber].Set(true);
+                        }
+                    }
+                }
+            }
+
+            public void Reset()
+            {
+                // IRQs are cleared on parent reset
+                // Don't clear state array here - it represents the state of input signals, not a property of this peripheral
+            }
+
+            private readonly bool[] state;
+            private readonly STM32H5_EXTI parent;
+            private readonly int portNumber;
+        }
+
+        private enum Registers
+        {
+            // Bank 1: trigger/pending group (stride 0x20 between banks)
+            RisingTriggerSelection1     = 0x00, // EXTI_RTSR1
+            FallingTriggerSelection1    = 0x04, // EXTI_FTSR1
+            SoftwareInterruptEvent1     = 0x08, // EXTI_SWIER1
+            RisingPending1              = 0x0C, // EXTI_RPR1
+            FallingPending1             = 0x10, // EXTI_FPR1
+            SecurityConfiguration1      = 0x14, // EXTI_SECCFGR1
+            PrivilegeConfiguration1     = 0x18, // EXTI_PRIVCFGR1
+            // Bank 2: trigger/pending group
+            RisingTriggerSelection2     = 0x20, // EXTI_RTSR2
+            FallingTriggerSelection2    = 0x24, // EXTI_FTSR2
+            SoftwareInterruptEvent2     = 0x28, // EXTI_SWIER2
+            RisingPending2              = 0x2C, // EXTI_RPR2
+            FallingPending2             = 0x30, // EXTI_FPR2
+            SecurityConfiguration2      = 0x34, // EXTI_SECCFGR2
+            PrivilegeConfiguration2     = 0x38, // EXTI_PRIVCFGR2
+            // EXTICR mux (port selection for GPIO lines 0-15)
+            ExternalInterruptSelection1 = 0x60, // EXTI_EXTICR1
+            ExternalInterruptSelection2 = 0x64, // EXTI_EXTICR2
+            ExternalInterruptSelection3 = 0x68, // EXTI_EXTICR3
+            ExternalInterruptSelection4 = 0x6C, // EXTI_EXTICR4
+            // Lock
+            Lock                        = 0x70, // EXTI_LOCKR
+            // Mask group (stride 0x10 between banks, starting at 0x80)
+            InterruptMask1              = 0x80, // EXTI_IMR1
+            EventMask1                  = 0x84, // EXTI_EMR1
+            InterruptMask2              = 0x90, // EXTI_IMR2
+            EventMask2                  = 0x94, // EXTI_EMR2
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/MTD/STM32H5_FlashController.cs
+++ b/src/Emulator/Peripherals/Peripherals/MTD/STM32H5_FlashController.cs
@@ -1,0 +1,362 @@
+//
+// Copyright (c) 2010-2026 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using System.Linq;
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Logging.Profiling;
+using Antmicro.Renode.Peripherals.Bus;
+using Antmicro.Renode.Peripherals.CPU;
+using Antmicro.Renode.Peripherals.Memory;
+
+namespace Antmicro.Renode.Peripherals.MTD
+{
+    [AllowedTranslations(AllowedTranslation.ByteToDoubleWord | AllowedTranslation.WordToDoubleWord)]
+    public class STM32H5_FlashController : STM32_FlashController, IKnownSize
+    {
+        public STM32H5_FlashController(IMachine machine, MappedMemory flash) : base(machine)
+        {
+            this.flash = flash;
+            nonSecureLock = new LockRegister(this, nameof(nonSecureLock), NonSecureKeys);
+
+            DefineRegisters();
+            Reset();
+        }
+
+        public GPIO IRQ { get; } = new GPIO();
+
+        public override void Reset()
+        {
+            base.Reset();
+            nonSecureLock.Reset();
+            writeBufferCounter = 0;
+        }
+
+        public long Size => 0x400;
+
+        private void DefineRegisters()
+        {
+            Registers.AccessControl.Define(this, 0x00000000)
+                .WithValueField(0, 4, name: "LATENCY")
+                .WithValueField(4, 2, name: "WRHIGHFREQ")
+                .WithReservedBits(6, 2)
+                .WithFlag(8, name: "PRFTEN")
+                .WithReservedBits(9, 23);
+
+            Registers.NonSecureKey.Define(this)
+                .WithValueField(0, 32, FieldMode.Write, name: "NSKEY", writeCallback: (_, value) =>
+                {
+                    nonSecureLock.ConsumeValue((uint)value);
+                    if(nonSecureLock.DisabledUntilReset)
+                    {
+                        this.Log(LogLevel.Warning,
+                            "Bad unlock key 0x{0:X8} written to NSKEYR; flash stays locked until reset", value);
+                    }
+                });
+
+            Registers.OperationStatus.Define(this, 0x00000000)
+                .WithValueField(0, 20, FieldMode.Read, name: "ADDR_OP")
+                .WithReservedBits(20, 1)
+                .WithFlag(21, FieldMode.Read, name: "DATA_OP")
+                .WithFlag(22, FieldMode.Read, name: "BK_OP")
+                .WithFlag(23, FieldMode.Read, name: "SYSF_OP")
+                .WithFlag(24, FieldMode.Read, name: "OTP_OP")
+                .WithReservedBits(25, 4)
+                .WithValueField(29, 3, FieldMode.Read, name: "CODE_OP");
+
+            Registers.NonSecureStatus.Define(this, 0x00000000)
+                .WithFlag(0, FieldMode.Read, name: "BSY")
+                .WithFlag(1, FieldMode.Read, name: "WBNE",
+                    valueProviderCallback: _ => programWriteEnabled.Value && writeBufferCounter > 0)
+                .WithReservedBits(2, 1)
+                .WithFlag(3, FieldMode.Read, name: "DBNE")
+                .WithReservedBits(4, 12)
+                .WithFlag(16, out eop, name: "EOP")
+                .WithFlag(17, out wrperr, name: "WRPERR")
+                .WithFlag(18, out pgserr, name: "PGSERR")
+                .WithFlag(19, out strberr, name: "STRBERR")
+                .WithFlag(20, out incerr, name: "INCERR")
+                // OBKERR (bit 21), OBKWERR (bit 22), and OPTCHANGEERR (bit 23) are defined
+                // but never set by this model. They always read 0. This is deliberate:
+                // defining them keeps NSSR free of unhandled-bits warnings, which is required
+                // by the full-bit-coverage acceptance criterion. The option-byte and OBK
+                // functionality that would set these bits is out of scope for this version.
+                .WithFlag(21, out obkerr, name: "OBKERR")
+                .WithFlag(22, out obkwerr, name: "OBKWERR")
+                .WithFlag(23, out optchangeerr, name: "OPTCHANGEERR")
+                .WithReservedBits(24, 8);
+
+            Registers.NonSecureControl.Define(this, 0x00000001)
+                .WithFlag(0, FieldMode.Read | FieldMode.Set, name: "LOCK",
+                    valueProviderCallback: _ => nonSecureLock.IsLocked,
+                    changeCallback: (_, value) =>
+                    {
+                        if(value)
+                        {
+                            nonSecureLock.Lock();
+                        }
+                    })
+                .WithFlag(1, out programWriteEnabled, name: "PG",
+                    changeCallback: (_, val) => HandleProgramWriteEnableChange(val))
+                .WithFlag(2, out sectorEraseRequest, name: "SER")
+                .WithFlag(3, out bankEraseRequest, name: "BER")
+                .WithFlag(4, FieldMode.Read | FieldMode.Set, name: "FW",
+                    valueProviderCallback: _ => false,
+                    writeCallback: (_, val) => { if(val) FinishProgramWrite(); })
+                .WithFlag(5, FieldMode.Read | FieldMode.Set, name: "START",
+                    valueProviderCallback: _ => false,
+                    writeCallback: (_, val) => { if(val) PerformErase(); })
+                .WithValueField(6, 7, out sectorNumber, name: "SNB")
+                .WithReservedBits(13, 2)
+                .WithFlag(15, out massEraseRequest, name: "MER")
+                .WithFlag(16, out eopInterruptEnable, name: "EOPIE")
+                .WithFlag(17, out wrperrInterruptEnable, name: "WRPERRIE")
+                .WithFlag(18, out pgserrInterruptEnable, name: "PGSERRIE")
+                .WithFlag(19, out strberrInterruptEnable, name: "STRBERRIE")
+                .WithFlag(20, out incerrInterruptEnable, name: "INCERRIE")
+                .WithFlag(21, out obkerrInterruptEnable, name: "OBKERRIE")
+                .WithFlag(22, out obkwerrInterruptEnable, name: "OBKWERRIE")
+                .WithFlag(23, out optchangeerrInterruptEnable, name: "OPTCHANGEERRIE")
+                .WithReservedBits(24, 5)
+                .WithFlag(29, name: "INV")
+                .WithReservedBits(30, 1)
+                .WithFlag(31, out bankSelect, name: "BKSEL");
+
+            Registers.NonSecureClearControl.Define(this, 0x00000000)
+                .WithReservedBits(0, 16)
+                .WithFlag(16, FieldMode.Write, name: "CLR_EOP",
+                    writeCallback: (_, val) => { if(val) eop.Value = false; })
+                .WithFlag(17, FieldMode.Write, name: "CLR_WRPERR",
+                    writeCallback: (_, val) => { if(val) wrperr.Value = false; })
+                .WithFlag(18, FieldMode.Write, name: "CLR_PGSERR",
+                    writeCallback: (_, val) => { if(val) pgserr.Value = false; })
+                .WithFlag(19, FieldMode.Write, name: "CLR_STRBERR",
+                    writeCallback: (_, val) => { if(val) strberr.Value = false; })
+                .WithFlag(20, FieldMode.Write, name: "CLR_INCERR",
+                    writeCallback: (_, val) => { if(val) incerr.Value = false; })
+                .WithFlag(21, FieldMode.Write, name: "CLR_OBKERR",
+                    writeCallback: (_, val) => { if(val) obkerr.Value = false; })
+                .WithFlag(22, FieldMode.Write, name: "CLR_OBKWERR",
+                    writeCallback: (_, val) => { if(val) obkwerr.Value = false; })
+                .WithFlag(23, FieldMode.Write, name: "CLR_OPTCHANGEERR",
+                    writeCallback: (_, val) => { if(val) optchangeerr.Value = false; })
+                .WithReservedBits(24, 8)
+                .WithWriteCallback((_, __) => UpdateInterrupts());
+        }
+
+        private void PerformErase()
+        {
+            if(nonSecureLock.IsLocked)
+            {
+                this.Log(LogLevel.Warning, "Erase requested while flash is locked. Setting WRPERR.");
+                wrperr.Value = true;
+                UpdateInterrupts();
+                return;
+            }
+
+            // MER (mass erase) has highest priority — erases both banks
+            if(massEraseRequest.Value)
+            {
+                this.Log(LogLevel.Debug, "Mass erase: erasing both banks (0x{0:X} bytes)", FlashSizeDefault);
+                flash.SetRange(0, FlashSizeDefault, 0xFF);
+                eop.Value = true;
+                UpdateInterrupts();
+            }
+            // BER (bank erase) — erase the bank selected by BKSEL
+            else if(bankEraseRequest.Value)
+            {
+                var bankOffset = bankSelect.Value ? FlashBankSize : 0;
+                this.Log(LogLevel.Debug, "Bank erase: bank {0}, offset 0x{1:X}, size 0x{2:X}",
+                    bankSelect.Value ? 1 : 0, bankOffset, FlashBankSize);
+                flash.SetRange(bankOffset, FlashBankSize, 0xFF);
+                eop.Value = true;
+                UpdateInterrupts();
+            }
+            // SER (sector erase) — erase the sector identified by BKSEL + SNB
+            else if(sectorEraseRequest.Value)
+            {
+                var bank = bankSelect.Value ? 1 : 0;
+                var snb = (long)sectorNumber.Value;
+                var sectorStartAddr = bank * FlashBankSize + snb * FlashSectorSize;
+                this.Log(LogLevel.Debug, "Sector erase: bank {0}, sector {1}, offset 0x{2:X}, size 0x{3:X}",
+                    bank, snb, sectorStartAddr, FlashSectorSize);
+                flash.SetRange(sectorStartAddr, FlashSectorSize, 0xFF);
+                eop.Value = true;
+                UpdateInterrupts();
+            }
+            else
+            {
+                this.Log(LogLevel.Warning,
+                    "START bit set but none of MER, BER, or SER are set. No erase performed.");
+            }
+        }
+
+        private void HandleProgramWriteEnableChange(bool value)
+        {
+            if(value && nonSecureLock.IsLocked)
+            {
+                this.Log(LogLevel.Warning, "PG set while flash is locked. Setting PGSERR.");
+                pgserr.Value = true;
+                UpdateInterrupts();
+                return;
+            }
+
+            var cpus = machine.GetSystemBus(this).GetCPUs().OfType<ICPUWithMemoryAccessHooks>();
+            foreach(var cpu in cpus)
+            {
+                cpu.SetHookAtMemoryAccess(value ? (MemoryAccessHook)OnMemoryProgramWrite : null);
+            }
+
+            writeBufferCounter = 0;
+        }
+
+        private void OnMemoryProgramWrite(ulong pc, MemoryOperation operation, ulong virtualAddress, ulong physicalAddress, uint width, ulong value)
+        {
+            if(operation != MemoryOperation.MemoryWrite)
+            {
+                return;
+            }
+
+            var writeTarget = machine.GetSystemBus(this).WhatIsAt(physicalAddress)?.Peripheral;
+            if(writeTarget != flash)
+            {
+                return;
+            }
+
+            if(nonSecureLock.IsLocked)
+            {
+                this.Log(LogLevel.Warning, "Flash write while locked. Setting WRPERR.");
+                wrperr.Value = true;
+                UpdateInterrupts();
+                return;
+            }
+
+            if(!programWriteEnabled.Value || incerr.Value)
+            {
+                pgserr.Value = true;
+                UpdateInterrupts();
+                return;
+            }
+
+            if(writeBufferCounter == 0)
+            {
+                writeBufferAddress = physicalAddress;
+            }
+            else if(writeBufferAddress + (ulong)writeBufferCounter != physicalAddress)
+            {
+                incerr.Value = true;
+                UpdateInterrupts();
+                return;
+            }
+
+            writeBufferCounter += (int)width;
+
+            if(writeBufferCounter >= WriteBufferSize)
+            {
+                if(writeBufferCounter > WriteBufferSize)
+                {
+                    this.Log(LogLevel.Warning,
+                        "More than the required number of bytes ({0} bytes) have been written to flash",
+                        WriteBufferSize);
+                }
+                FinishProgramWrite();
+            }
+        }
+
+        private void FinishProgramWrite()
+        {
+            writeBufferCounter = 0;
+            eop.Value = true;
+            UpdateInterrupts();
+        }
+
+        private void UpdateInterrupts()
+        {
+            var irqStatus = (eopInterruptEnable.Value && eop.Value)
+                || (wrperrInterruptEnable.Value && wrperr.Value)
+                || (pgserrInterruptEnable.Value && pgserr.Value)
+                || (strberrInterruptEnable.Value && strberr.Value)
+                || (incerrInterruptEnable.Value && incerr.Value)
+                || (obkerrInterruptEnable.Value && obkerr.Value)
+                || (obkwerrInterruptEnable.Value && obkwerr.Value)
+                || (optchangeerrInterruptEnable.Value && optchangeerr.Value);
+            this.DebugLog("Set IRQ: {0}", irqStatus);
+            IRQ.Set(irqStatus);
+        }
+
+        // NSSR status fields
+        private IFlagRegisterField eop;
+        private IFlagRegisterField wrperr;
+        private IFlagRegisterField pgserr;
+        private IFlagRegisterField strberr;
+        private IFlagRegisterField incerr;
+        private IFlagRegisterField obkerr;
+        private IFlagRegisterField obkwerr;
+        private IFlagRegisterField optchangeerr;
+
+        // NSCR control fields for erase operations
+        private IFlagRegisterField sectorEraseRequest;
+        private IFlagRegisterField bankEraseRequest;
+        private IFlagRegisterField massEraseRequest;
+        private IValueRegisterField sectorNumber;
+        private IFlagRegisterField bankSelect;
+        private IFlagRegisterField programWriteEnabled;
+
+        // NSCR interrupt enable fields
+        private IFlagRegisterField eopInterruptEnable;
+        private IFlagRegisterField wrperrInterruptEnable;
+        private IFlagRegisterField pgserrInterruptEnable;
+        private IFlagRegisterField strberrInterruptEnable;
+        private IFlagRegisterField incerrInterruptEnable;
+        private IFlagRegisterField obkerrInterruptEnable;
+        private IFlagRegisterField obkwerrInterruptEnable;
+        private IFlagRegisterField optchangeerrInterruptEnable;
+
+        private readonly MappedMemory flash;
+        private readonly LockRegister nonSecureLock;
+
+        private int writeBufferCounter;
+        private ulong writeBufferAddress;
+
+        private static readonly uint[] NonSecureKeys = { 0x45670123, 0xCDEF89AB };
+
+        // Flash geometry: 2 MB total, 2 banks of 1 MB each, 128 sectors of 8 KB per bank
+        private const long FlashSizeDefault = 0x200000;       // 2 MB
+        private const long FlashBankSize = 0x100000;          // 1 MB
+        private const long FlashSectorSize = 0x2000;          // 8 KB
+        private const int WriteBufferSize = 16;               // 128-bit flash word
+
+        private enum Registers : long
+        {
+            AccessControl = 0x00,
+            NonSecureKey = 0x04,
+            // --- Scope boundary: out-of-scope registers and areas ---
+            //
+            // The following registers and areas are deliberately left undefined so that any
+            // access produces a warning-level log entry naming the peripheral and the offset,
+            // rather than silently returning zero:
+            //
+            //   OPTKEYR   0x0C  — option byte key register
+            //   OPTCR     0x1C  — option control register
+            //   OBK area registers (option byte key storage)
+            //   EDATA high-cycle area registers
+            //   HDP and watermark configuration registers
+            //   ECC registers: ECCCORR, ECCDETR, ECCDR
+            //
+            // This model implements no option-byte LockRegister, no OPTSTART PRG→CUR
+            // copying, and no ECC status or error injection. Program and erase are the
+            // scope boundary for this version.
+            //
+            OperationStatus = 0x18,
+            NonSecureStatus = 0x20,
+            NonSecureControl = 0x28,
+            NonSecureClearControl = 0x30,
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/STM32H5_PWR.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/STM32H5_PWR.cs
@@ -47,7 +47,8 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTag("BDCR", 0, 32);
 
             Registers.DebugPortControl.Define(this)
-                .WithTag("DBPCR", 0, 32);
+                .WithFlag(0, name: "DBP")
+                .WithReservedBits(1, 31);
 
             Registers.BackupDomainStatus.Define(this)
                 .WithTag("BDSR", 0, 32);

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/STM32H5_PWR.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/STM32H5_PWR.cs
@@ -1,0 +1,113 @@
+//
+// Copyright (c) 2010-2025 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Peripherals.Bus;
+
+namespace Antmicro.Renode.Peripherals.Miscellaneous
+{
+    [AllowedTranslations(AllowedTranslation.ByteToDoubleWord | AllowedTranslation.WordToDoubleWord)]
+    public sealed class STM32H5_PWR : BasicDoubleWordPeripheral, IKnownSize
+    {
+        public STM32H5_PWR(IMachine machine) : base(machine)
+        {
+            DefineRegisters();
+            Reset();
+        }
+
+        public long Size => 0x400;
+
+        private void DefineRegisters()
+        {
+            Registers.PowerModeControl.Define(this)
+                .WithTag("PMCR", 0, 32);
+
+            Registers.PowerModeStatus.Define(this)
+                .WithTag("PMSR", 0, 32);
+
+            Registers.VoltageScalingControl.Define(this)
+                .WithReservedBits(0, 4)
+                .WithValueField(4, 2, out vosValue, name: "VOS")
+                .WithReservedBits(6, 26);
+
+            Registers.VoltageScalingStatus.Define(this)
+                .WithReservedBits(0, 3)
+                .WithFlag(3, FieldMode.Read, valueProviderCallback: _ => true, name: "VOSRDY")
+                .WithReservedBits(4, 9)
+                .WithFlag(13, FieldMode.Read, valueProviderCallback: _ => true, name: "ACTVOSRDY")
+                .WithValueField(14, 2, FieldMode.Read, valueProviderCallback: _ => vosValue.Value, name: "ACTVOS")
+                .WithReservedBits(16, 16);
+
+            Registers.BackupDomainControl.Define(this)
+                .WithTag("BDCR", 0, 32);
+
+            Registers.DebugPortControl.Define(this)
+                .WithTag("DBPCR", 0, 32);
+
+            Registers.BackupDomainStatus.Define(this)
+                .WithTag("BDSR", 0, 32);
+
+            Registers.USBTypeCPowerDelivery.Define(this)
+                .WithTag("UCPDR", 0, 32);
+
+            Registers.SupplyConfigurationControl.Define(this)
+                .WithTag("SCCR", 0, 32);
+
+            Registers.VoltageMonitoringControl.Define(this)
+                .WithTag("VMCR", 0, 32);
+
+            Registers.USBSupplyControl.Define(this)
+                .WithTag("USBSCR", 0, 32);
+
+            Registers.VoltageMonitoringStatus.Define(this)
+                .WithTag("VMSR", 0, 32);
+
+            Registers.WakeupStatusClear.Define(this)
+                .WithTag("WUSCR", 0, 32);
+
+            Registers.WakeupStatus.Define(this)
+                .WithTag("WUSR", 0, 32);
+
+            Registers.WakeupControl.Define(this)
+                .WithTag("WUCR", 0, 32);
+
+            Registers.IORetention.Define(this)
+                .WithTag("IORETR", 0, 32);
+
+            Registers.SecurityConfiguration.Define(this)
+                .WithTag("SECCFGR", 0, 32);
+
+            Registers.PrivilegeConfiguration.Define(this)
+                .WithTag("PRIVCFGR", 0, 32);
+        }
+
+        private IValueRegisterField vosValue;
+
+        private enum Registers
+        {
+            PowerModeControl = 0x00,
+            PowerModeStatus = 0x04,
+            VoltageScalingControl = 0x10,
+            VoltageScalingStatus = 0x14,
+            BackupDomainControl = 0x20,
+            DebugPortControl = 0x24,
+            BackupDomainStatus = 0x28,
+            USBTypeCPowerDelivery = 0x2C,
+            SupplyConfigurationControl = 0x30,
+            VoltageMonitoringControl = 0x34,
+            USBSupplyControl = 0x38,
+            VoltageMonitoringStatus = 0x3C,
+            WakeupStatusClear = 0x40,
+            WakeupStatus = 0x44,
+            WakeupControl = 0x48,
+            IORetention = 0x50,
+            SecurityConfiguration = 0x100,
+            PrivilegeConfiguration = 0x104,
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/STM32H5_RCC.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/STM32H5_RCC.cs
@@ -1,0 +1,516 @@
+//
+// Copyright (c) 2010-2025 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+
+// Known limitation, deliberate for this version:
+// The peripheral clock enable (*ENR) and peripheral reset (*RSTR) register blocks are
+// storage only. Writes are preserved for read-back, but the model does not gate the clock
+// of the addressed peripheral and does not assert its reset.
+//
+// Modelling this would mean propagating enable and reset state from each *ENR/*RSTR bit to
+// the corresponding modelled peripheral instance, so that accessing a clock-gated
+// peripheral is diagnosable and a reset request actually resets the peripheral's state.
+// Nothing in the currently supported firmware depends on it.
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Peripherals.Bus;
+
+namespace Antmicro.Renode.Peripherals.Miscellaneous
+{
+    [AllowedTranslations(AllowedTranslation.ByteToDoubleWord | AllowedTranslation.WordToDoubleWord)]
+    public class STM32H5_RCC : BasicDoubleWordPeripheral, IKnownSize
+    {
+        public STM32H5_RCC(IMachine machine,
+            IHasFrequency nvic = null,
+            IHasFrequency usart3 = null,
+            ulong hseFrequency = DefaultHseFrequency,
+            ulong lseFrequency = DefaultLseFrequency,
+            ulong lsiFrequency = DefaultLsiFrequency) : base(machine)
+        {
+            this.nvic = nvic;
+            this.usart3 = usart3;
+            this.hseFrequency = hseFrequency;
+            this.lseFrequency = lseFrequency;
+            this.lsiFrequency = lsiFrequency;
+            DefineRegisters();
+            Reset();
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            UpdateClocks();
+        }
+
+        public long Size => 0x400;
+
+        // Clock propagation targets:
+        //   nvic   — HCLK, so SysTick (HAL_GetTick) follows the real clock tree
+        //   usart3 — PCLK1, for baud rate generation (wired in task 9.2 once STM32F7_USART
+        //            implements IHasFrequency; null until then — staged, not forgotten)
+        //
+        // Deliberately excluded:
+        //   IWDG — LSI-clocked at a fixed 32 kHz; its constructor frequency is already correct.
+
+        private static void TrySetFrequency(IHasFrequency peripheral, ulong frequency)
+        {
+            if(peripheral != null)
+            {
+                peripheral.Frequency = frequency;
+            }
+        }
+
+        private void UpdateClocks()
+        {
+            TrySetFrequency(nvic, HclkFrequency);
+            TrySetFrequency(usart3, Pclk1Frequency);
+        }
+
+        private void DefineRegisters()
+        {
+            // Reset values from RM0481 Rev 4, Section 11.8 (RCC register descriptions):
+            //   CR        = 0x0000_0023 (HSION, HSIRDY, HSIDIVF set)
+            //   CFGR1     = 0x0000_0000
+            //   CFGR2     = 0x0000_0000
+            //   PLL1CFGR  = 0x0000_0000
+            //   PLL1DIVR  = 0x0101_0280 (PLL1N=128, PLL1P=1, PLL1Q=1, PLL1R=1)
+
+            Registers.ClockControl.Define(this, 0x23)
+                .WithFlag(0, out var hsiOn, name: "HSION")
+                .WithFlag(1, FieldMode.Read, valueProviderCallback: _ => hsiOn.Value, name: "HSIRDY")
+                .WithFlag(2, name: "HSIKERON")
+                .WithValueField(3, 2, out hsidiv, name: "HSIDIV", writeCallback: (_, __) => { hsidivf.Value = true; })
+                .WithFlag(5, out hsidivf, name: "HSIDIVF")
+                .WithReservedBits(6, 2)
+                .WithFlag(8, out var csiOn, name: "CSION")
+                .WithFlag(9, FieldMode.Read, valueProviderCallback: _ => csiOn.Value, name: "CSIRDY")
+                .WithFlag(10, name: "CSIKERON")
+                .WithReservedBits(11, 1)
+                .WithFlag(12, out var hsi48On, name: "HSI48ON")
+                .WithFlag(13, FieldMode.Read, valueProviderCallback: _ => hsi48On.Value, name: "HSI48RDY")
+                .WithReservedBits(14, 2)
+                .WithFlag(16, out var hseOn, name: "HSEON")
+                .WithFlag(17, FieldMode.Read, valueProviderCallback: _ => hseOn.Value, name: "HSERDY")
+                .WithFlag(18, name: "HSEBYP")
+                .WithFlag(19, name: "HSECSSON")
+                .WithFlag(20, name: "HSEEXT")
+                .WithReservedBits(21, 3)
+                .WithFlag(24, out var pll1On, name: "PLL1ON")
+                .WithFlag(25, FieldMode.Read, valueProviderCallback: _ => pll1On.Value, name: "PLL1RDY")
+                .WithFlag(26, out var pll2On, name: "PLL2ON")
+                .WithFlag(27, FieldMode.Read, valueProviderCallback: _ => pll2On.Value, name: "PLL2RDY")
+                .WithFlag(28, out var pll3On, name: "PLL3ON")
+                .WithFlag(29, FieldMode.Read, valueProviderCallback: _ => pll3On.Value, name: "PLL3RDY")
+                .WithReservedBits(30, 2)
+                .WithChangeCallback((_, __) => UpdateClocks());
+
+            Registers.HSICalibration.Define(this)
+                .WithTag("HSICFGR", 0, 32);
+
+            Registers.ClockRecoveryRC.Define(this)
+                .WithTag("CRRCR", 0, 32);
+
+            Registers.CSICalibration.Define(this)
+                .WithTag("CSICFGR", 0, 32);
+
+            Registers.ClockConfiguration1.Define(this)
+                .WithValueField(0, 3, out systemClockSwitch, name: "SW")
+                .WithValueField(3, 3, FieldMode.Read, valueProviderCallback: _ => systemClockSwitch.Value, name: "SWS")
+                .WithFlag(6, name: "STOPWUCK")
+                .WithFlag(7, name: "STOPKERWUCK")
+                .WithValueField(8, 6, name: "RTCPRE")
+                .WithReservedBits(14, 1)
+                .WithFlag(15, name: "TIMPRE")
+                .WithReservedBits(16, 2)
+                .WithValueField(18, 4, name: "MCO1PRE")
+                .WithValueField(22, 3, name: "MCO1")
+                .WithValueField(25, 4, name: "MCO2PRE")
+                .WithValueField(29, 3, name: "MCO2")
+                .WithChangeCallback((_, __) => UpdateClocks());
+
+            Registers.ClockConfiguration2.Define(this)
+                .WithValueField(0, 4, out hpre, name: "HPRE")
+                .WithValueField(4, 3, out ppre1, name: "PPRE1")
+                .WithReservedBits(7, 1)
+                .WithValueField(8, 3, name: "PPRE2")
+                .WithReservedBits(11, 1)
+                .WithValueField(12, 3, name: "PPRE3")
+                .WithReservedBits(15, 1)
+                .WithFlag(16, name: "AHB1DIS")
+                .WithFlag(17, name: "AHB2DIS")
+                .WithReservedBits(18, 1)
+                .WithFlag(19, name: "AHB4DIS")
+                .WithFlag(20, name: "APB1DIS")
+                .WithFlag(21, name: "APB2DIS")
+                .WithFlag(22, name: "APB3DIS")
+                .WithReservedBits(23, 9)
+                .WithChangeCallback((_, __) => UpdateClocks());
+
+            Registers.PLL1Configuration.Define(this)
+                .WithValueField(0, 2, out pll1Src, name: "PLL1SRC")
+                .WithValueField(2, 2, name: "PLL1RGE")
+                .WithFlag(4, out pll1FracEn, name: "PLL1FRACEN")
+                .WithFlag(5, name: "PLL1VCOSEL")
+                .WithReservedBits(6, 2)
+                .WithValueField(8, 6, out pll1M, name: "PLL1M")
+                .WithReservedBits(14, 2)
+                .WithFlag(16, name: "PLL1PEN")
+                .WithFlag(17, name: "PLL1QEN")
+                .WithFlag(18, name: "PLL1REN")
+                .WithReservedBits(19, 13)
+                .WithChangeCallback((_, __) => UpdateClocks());
+
+            Registers.PLL2Configuration.Define(this)
+                .WithValueField(0, 2, name: "PLL2SRC")
+                .WithValueField(2, 2, name: "PLL2RGE")
+                .WithFlag(4, name: "PLL2FRACEN")
+                .WithFlag(5, name: "PLL2VCOSEL")
+                .WithReservedBits(6, 2)
+                .WithValueField(8, 6, name: "PLL2M")
+                .WithReservedBits(14, 2)
+                .WithFlag(16, name: "PLL2PEN")
+                .WithFlag(17, name: "PLL2QEN")
+                .WithFlag(18, name: "PLL2REN")
+                .WithReservedBits(19, 13);
+
+            Registers.PLL3Configuration.Define(this)
+                .WithValueField(0, 2, name: "PLL3SRC")
+                .WithValueField(2, 2, name: "PLL3RGE")
+                .WithFlag(4, name: "PLL3FRACEN")
+                .WithFlag(5, name: "PLL3VCOSEL")
+                .WithReservedBits(6, 2)
+                .WithValueField(8, 6, name: "PLL3M")
+                .WithReservedBits(14, 2)
+                .WithFlag(16, name: "PLL3PEN")
+                .WithFlag(17, name: "PLL3QEN")
+                .WithFlag(18, name: "PLL3REN")
+                .WithReservedBits(19, 13);
+
+            Registers.PLL1Dividers.Define(this, 0x01010280)
+                .WithValueField(0, 9, out pll1N, name: "PLL1N")
+                .WithValueField(9, 7, out pll1P, name: "PLL1P")
+                .WithValueField(16, 7, name: "PLL1Q")
+                .WithReservedBits(23, 1)
+                .WithValueField(24, 7, name: "PLL1R")
+                .WithReservedBits(31, 1)
+                .WithChangeCallback((_, __) => UpdateClocks());
+
+            Registers.PLL1Fractional.Define(this)
+                .WithReservedBits(0, 3)
+                .WithValueField(3, 13, out pll1FracN, name: "PLL1FRACN")
+                .WithReservedBits(16, 16)
+                .WithChangeCallback((_, __) => UpdateClocks());
+
+            Registers.PLL2Dividers.Define(this)
+                .WithValueField(0, 9, name: "PLL2N")
+                .WithValueField(9, 7, name: "PLL2P")
+                .WithValueField(16, 7, name: "PLL2Q")
+                .WithReservedBits(23, 1)
+                .WithValueField(24, 7, name: "PLL2R")
+                .WithReservedBits(31, 1);
+
+            Registers.PLL2Fractional.Define(this)
+                .WithReservedBits(0, 3)
+                .WithValueField(3, 13, name: "PLL2FRACN")
+                .WithReservedBits(16, 16);
+
+            Registers.PLL3Dividers.Define(this)
+                .WithValueField(0, 9, name: "PLL3N")
+                .WithValueField(9, 7, name: "PLL3P")
+                .WithValueField(16, 7, name: "PLL3Q")
+                .WithReservedBits(23, 1)
+                .WithValueField(24, 7, name: "PLL3R")
+                .WithReservedBits(31, 1);
+
+            Registers.PLL3Fractional.Define(this)
+                .WithReservedBits(0, 3)
+                .WithValueField(3, 13, name: "PLL3FRACN")
+                .WithReservedBits(16, 16);
+
+            // CIER/CIFR/CICR: storage only, no interrupt generation
+            Registers.ClockInterruptEnable.Define(this)
+                .WithTag("CIER", 0, 32);
+
+            Registers.ClockInterruptFlag.Define(this)
+                .WithTag("CIFR", 0, 32);
+
+            Registers.ClockInterruptClear.Define(this)
+                .WithTag("CICR", 0, 32);
+
+            // Reset registers: storage only (see file header comment)
+            Registers.AHB1Reset.Define(this)
+                .WithTag("AHB1RSTR", 0, 32);
+
+            Registers.AHB2Reset.Define(this)
+                .WithTag("AHB2RSTR", 0, 32);
+
+            Registers.AHB4Reset.Define(this)
+                .WithTag("AHB4RSTR", 0, 32);
+
+            Registers.APB1LowReset.Define(this)
+                .WithTag("APB1LRSTR", 0, 32);
+
+            Registers.APB1HighReset.Define(this)
+                .WithTag("APB1HRSTR", 0, 32);
+
+            Registers.APB2Reset.Define(this)
+                .WithTag("APB2RSTR", 0, 32);
+
+            Registers.APB3Reset.Define(this)
+                .WithTag("APB3RSTR", 0, 32);
+
+            // Enable registers: storage only (see file header comment)
+            Registers.AHB1Enable.Define(this)
+                .WithTag("AHB1ENR", 0, 32);
+
+            Registers.AHB2Enable.Define(this)
+                .WithTag("AHB2ENR", 0, 32);
+
+            Registers.AHB4Enable.Define(this)
+                .WithTag("AHB4ENR", 0, 32);
+
+            Registers.APB1LowEnable.Define(this)
+                .WithTag("APB1LENR", 0, 32);
+
+            Registers.APB1HighEnable.Define(this)
+                .WithTag("APB1HENR", 0, 32);
+
+            Registers.APB2Enable.Define(this)
+                .WithTag("APB2ENR", 0, 32);
+
+            Registers.APB3Enable.Define(this)
+                .WithTag("APB3ENR", 0, 32);
+
+            // Low-power enable registers: storage only
+            Registers.AHB1LowPowerEnable.Define(this)
+                .WithTag("AHB1LPENR", 0, 32);
+
+            Registers.AHB2LowPowerEnable.Define(this)
+                .WithTag("AHB2LPENR", 0, 32);
+
+            Registers.AHB4LowPowerEnable.Define(this)
+                .WithTag("AHB4LPENR", 0, 32);
+
+            Registers.APB1LowLowPowerEnable.Define(this)
+                .WithTag("APB1LLPENR", 0, 32);
+
+            Registers.APB1HighLowPowerEnable.Define(this)
+                .WithTag("APB1HLPENR", 0, 32);
+
+            Registers.APB2LowPowerEnable.Define(this)
+                .WithTag("APB2LPENR", 0, 32);
+
+            Registers.APB3LowPowerEnable.Define(this)
+                .WithTag("APB3LPENR", 0, 32);
+
+            // Clock configuration input peripheral registers: storage for now
+            Registers.ClockConfigurationInput1.Define(this)
+                .WithValueField(0, 32, name: "CCIPR1");
+
+            Registers.ClockConfigurationInput2.Define(this)
+                .WithValueField(0, 32, name: "CCIPR2");
+
+            Registers.ClockConfigurationInput3.Define(this)
+                .WithValueField(0, 32, name: "CCIPR3");
+
+            Registers.ClockConfigurationInput4.Define(this)
+                .WithValueField(0, 32, name: "CCIPR4");
+
+            Registers.ClockConfigurationInput5.Define(this)
+                .WithValueField(0, 32, name: "CCIPR5");
+
+            Registers.BackupDomainControl.Define(this)
+                .WithFlag(0, out var lseOn, name: "LSEON")
+                .WithFlag(1, FieldMode.Read, valueProviderCallback: _ => lseOn.Value, name: "LSERDY")
+                .WithFlag(2, name: "LSEBYP")
+                .WithValueField(3, 2, name: "LSEDRV")
+                .WithFlag(5, name: "LSECSSON")
+                .WithFlag(6, name: "LSECSSD")
+                .WithFlag(7, name: "LSESYSEN")
+                .WithValueField(8, 2, name: "RTCSEL")
+                .WithReservedBits(10, 3)
+                .WithFlag(13, name: "LSESYSRDY")
+                .WithFlag(14, name: "LSEGFON")
+                .WithFlag(15, name: "RTCEN")
+                .WithFlag(16, name: "VSWRST")
+                .WithReservedBits(17, 9)
+                .WithFlag(26, out var lsiOn, name: "LSION")
+                .WithFlag(27, FieldMode.Read, valueProviderCallback: _ => lsiOn.Value, name: "LSIRDY")
+                .WithReservedBits(28, 4);
+
+            Registers.ResetStatus.Define(this)
+                .WithTag("RSR", 0, 32);
+
+            Registers.SecurityConfiguration.Define(this)
+                .WithTag("SECCFGR", 0, 32);
+
+            Registers.PrivilegeConfiguration.Define(this)
+                .WithTag("PRIVCFGR", 0, 32);
+        }
+
+        public ulong SysclkFrequency
+        {
+            get
+            {
+                switch((uint)systemClockSwitch.Value)
+                {
+                    case 0: // HSI
+                        return hsidivf.Value ? HsiFrequency >> (int)hsidiv.Value : HsiFrequency;
+                    case 1: // CSI
+                        return CsiFrequency;
+                    case 2: // HSE
+                        return hseFrequency;
+                    case 3: // PLL1P
+                        return ComputePll1PFrequency();
+                    default:
+                        return HsiFrequency;
+                }
+            }
+        }
+
+        public ulong HclkFrequency
+        {
+            get
+            {
+                return SysclkFrequency >> AHBPrescTable[(int)hpre.Value];
+            }
+        }
+
+        public ulong Pclk1Frequency
+        {
+            get
+            {
+                return HclkFrequency >> APBPrescTable[(int)ppre1.Value];
+            }
+        }
+
+        private ulong ComputePll1PFrequency()
+        {
+            var m = (uint)pll1M.Value;
+            if(m == 0)
+            {
+                return 0;
+            }
+
+            ulong source;
+            switch((uint)pll1Src.Value)
+            {
+                case 1: // HSI (after HSIDIV)
+                    source = hsidivf.Value ? HsiFrequency >> (int)hsidiv.Value : HsiFrequency;
+                    break;
+                case 2: // CSI
+                    source = CsiFrequency;
+                    break;
+                case 3: // HSE
+                    source = hseFrequency;
+                    break;
+                default: // 0 = no clock
+                    return 0;
+            }
+
+            var fracContribution = pll1FracEn.Value ? (ulong)pll1FracN.Value : 0UL;
+            var n = (ulong)pll1N.Value + (fracContribution * 1UL / 0x2000UL) + 1UL;
+            var p = (ulong)pll1P.Value + 1UL;
+
+            return (source / m) * n / p;
+        }
+
+        private readonly IHasFrequency nvic;
+        private readonly IHasFrequency usart3;
+        private readonly ulong hseFrequency;
+        private readonly ulong lseFrequency;
+        private readonly ulong lsiFrequency;
+
+        private IFlagRegisterField hsidivf;
+        private IValueRegisterField hsidiv;
+        private IValueRegisterField systemClockSwitch;
+        private IValueRegisterField hpre;
+        private IValueRegisterField ppre1;
+        private IValueRegisterField pll1Src;
+        private IFlagRegisterField pll1FracEn;
+        private IValueRegisterField pll1M;
+        private IValueRegisterField pll1N;
+        private IValueRegisterField pll1P;
+        private IValueRegisterField pll1FracN;
+
+        private const ulong HsiFrequency = 64000000;
+        private const ulong CsiFrequency = 4000000;
+        private const ulong DefaultHseFrequency = 8000000;
+        private const ulong DefaultLseFrequency = 32768;
+        private const ulong DefaultLsiFrequency = 32000;
+
+        private static readonly int[] AHBPrescTable = { 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9 };
+        private static readonly int[] APBPrescTable = { 0, 0, 0, 0, 1, 2, 3, 4 };
+
+        private enum Registers
+        {
+            ClockControl = 0x00,
+            // 0x04, 0x08, 0x0C reserved
+            HSICalibration = 0x10,
+            ClockRecoveryRC = 0x14,
+            CSICalibration = 0x18,
+            ClockConfiguration1 = 0x1C,
+            ClockConfiguration2 = 0x20,
+            // 0x24 reserved
+            PLL1Configuration = 0x28,
+            PLL2Configuration = 0x2C,
+            PLL3Configuration = 0x30,
+            PLL1Dividers = 0x34,
+            PLL1Fractional = 0x38,
+            PLL2Dividers = 0x3C,
+            PLL2Fractional = 0x40,
+            PLL3Dividers = 0x44,
+            PLL3Fractional = 0x48,
+            // 0x4C reserved
+            ClockInterruptEnable = 0x50,
+            ClockInterruptFlag = 0x54,
+            ClockInterruptClear = 0x58,
+            // 0x5C reserved
+            AHB1Reset = 0x60,
+            AHB2Reset = 0x64,
+            // 0x68 reserved
+            AHB4Reset = 0x6C,
+            // 0x70 reserved
+            APB1LowReset = 0x74,
+            APB1HighReset = 0x78,
+            APB2Reset = 0x7C,
+            APB3Reset = 0x80,
+            // 0x84 reserved
+            AHB1Enable = 0x88,
+            AHB2Enable = 0x8C,
+            // 0x90 reserved
+            AHB4Enable = 0x94,
+            // 0x98 reserved
+            APB1LowEnable = 0x9C,
+            APB1HighEnable = 0xA0,
+            APB2Enable = 0xA4,
+            APB3Enable = 0xA8,
+            // 0xAC reserved
+            AHB1LowPowerEnable = 0xB0,
+            AHB2LowPowerEnable = 0xB4,
+            // 0xB8 reserved
+            AHB4LowPowerEnable = 0xBC,
+            // 0xC0 reserved
+            APB1LowLowPowerEnable = 0xC4,
+            APB1HighLowPowerEnable = 0xC8,
+            APB2LowPowerEnable = 0xCC,
+            APB3LowPowerEnable = 0xD0,
+            // 0xD4 reserved
+            ClockConfigurationInput1 = 0xD8,
+            ClockConfigurationInput2 = 0xDC,
+            ClockConfigurationInput3 = 0xE0,
+            ClockConfigurationInput4 = 0xE4,
+            ClockConfigurationInput5 = 0xE8,
+            // 0xEC reserved
+            BackupDomainControl = 0xF0,
+            ResetStatus = 0xF4,
+            // 0xF8 - 0x10C reserved
+            SecurityConfiguration = 0x110,
+            PrivilegeConfiguration = 0x114,
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/STM32_RNG.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/STM32_RNG.cs
@@ -22,6 +22,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             var supportedSeries = new List<STM32Series>{
                 STM32Series.F4,
                 STM32Series.F7,
+                STM32Series.H5,
                 STM32Series.H7,
                 STM32Series.L0,
                 STM32Series.L5,
@@ -32,24 +33,27 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             }
             this.series = series;
 
+            var hasExtendedControl = series == STM32Series.L5 || series == STM32Series.H5;
+
             var registerMap = new Dictionary<long, DoubleWordRegister>
             {
                 {(long)Registers.Control, new DoubleWordRegister(this)
                     .WithReservedBits(0, 2)
                     .WithFlag(2, out enable, changeCallback: (_, value) => Update(), name: "RNGEN")
                     .WithFlag(3, out interruptEnable, changeCallback: (_, value) => Update(), name: "IE")
-                    .If(series == STM32Series.L5)
+                    .If(hasExtendedControl)
                         .Then(reg => reg
                             .WithReservedBits(4, 1)
                             .WithTaggedFlag("CED", 5)
-                            .WithReservedBits(6, 2)
-                            .WithTag("RND_CONFIG3", 8, 4)
+                            .WithReservedBits(6, 1)
+                            .WithTaggedFlag("ARDIS", 7)
+                            .WithTag("RNG_CONFIG3", 8, 4)
                             .WithTaggedFlag("NISTC", 12)
-                            .WithTag("RND_CONFIG2", 13, 3)
+                            .WithTag("RNG_CONFIG2", 13, 3)
                             .WithTag("CLKDIV", 16, 4)
-                            .WithTag("RND_CONFIG1", 20, 6)
+                            .WithTag("RNG_CONFIG1", 20, 6)
                             .WithReservedBits(26, 4)
-                            .WithFlag(30, name: "CONDRST") //Nothing to do for the emulation
+                            .WithFlag(30, name: "CONDRST")
                             .WithTaggedFlag("CONFIGLOCK", 31)
                         )
                         .Else(reg => reg
@@ -79,17 +83,30 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 }, name: "RNDATA")
                 },
             };
+            if(series == STM32Series.H5)
+            {
+                registerMap.Add((long)Registers.NoiseSourceControl, new DoubleWordRegister(this)
+                    .WithValueField(0, 18, name: "NSCR")
+                    .WithReservedBits(18, 14)
+                );
+            }
             if(series == STM32Series.L5)
             {
                 registerMap.Add((long)Registers.HealthTestControl, new DoubleWordRegister(this)
-                        .WithValueField(0, 32, writeCallback: (previous_value, new_value) =>
+                    .WithValueField(0, 32, writeCallback: (previous_value, new_value) =>
+                    {
+                        if(previous_value != HealthTestControlMagicL5 && new_value != HealthTestControlMagicL5)
                         {
-                            if(previous_value != HealthTestControlMagic && new_value != HealthTestControlMagic)
-                            {
-                                this.Log(LogLevel.Warning, "Magic value 0x{0:X} not written before 0x{1:X}", HealthTestControlMagic, new_value);
-                            }
+                            this.Log(LogLevel.Warning, "Magic value 0x{0:X} not written before 0x{1:X}", HealthTestControlMagicL5, new_value);
                         }
-                        ));
+                    })
+                );
+            }
+            else if(series == STM32Series.H5)
+            {
+                registerMap.Add((long)Registers.HealthTestControl, new DoubleWordRegister(this)
+                    .WithValueField(0, 32, name: "HTCR")
+                );
             }
             registers = new DoubleWordRegisterCollection(this, registerMap);
         }
@@ -124,13 +141,14 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         private readonly IFlagRegisterField interruptEnable;
         private readonly STM32Series series;
 
-        private const uint HealthTestControlMagic = 0x17590ABC;
+        private const uint HealthTestControlMagicL5 = 0x17590ABC;
 
         private enum Registers
         {
             Control = 0x0,
             Status = 0x4,
             Data = 0x8,
+            NoiseSourceControl = 0x0C,
             HealthTestControl = 0x10,
         }
     }

--- a/src/Emulator/Peripherals/Peripherals/STM32Series.cs
+++ b/src/Emulator/Peripherals/Peripherals/STM32Series.cs
@@ -54,6 +54,11 @@ namespace Antmicro.Renode.Peripherals
          */
         L5,
 
+        /* For H5 series technical documentation and reference manuals, see
+         * https://www.st.com/en/microcontrollers-microprocessors/stm32h5-series/documentation.html
+         */
+        H5,
+
         /* For WBA series technical documentation and reference manuals, see
          * https://www.st.com/en/microcontrollers-microprocessors/stm32wba-series/documentation.html
          */

--- a/src/Emulator/Peripherals/Peripherals/Timers/STM32_IndependentWatchdog.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/STM32_IndependentWatchdog.cs
@@ -19,12 +19,13 @@ namespace Antmicro.Renode.Peripherals.Timers
     {
         //TODO: Stop timer on debug stop.
         //TODO: Use RCC to set restart cause.
-        public STM32_IndependentWatchdog(IMachine machine, ulong frequency, bool windowOption = true, uint defaultPrescaler = 0) : base(machine)
+        public STM32_IndependentWatchdog(IMachine machine, ulong frequency, bool windowOption = true, bool earlyWakeupOption = false, uint defaultPrescaler = 0) : base(machine)
         {
             watchdogTimer = new LimitTimer(machine.ClockSource, frequency, this, "STM32_IWDG", DefaultReloadValue, workMode: WorkMode.OneShot, enabled: false, eventEnabled: true, autoUpdate: true, divider: DefaultPrescalerValue);
             watchdogTimer.LimitReached += TimerLimitReachedCallback;
             this.defaultPrescaler = defaultPrescaler;
             this.windowOption = windowOption;
+            this.earlyWakeupOption = earlyWakeupOption;
             DefineRegisters();
             Reset();
         }
@@ -37,6 +38,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             reloadValue = DefaultReloadValue;
             window = DefaultWindow;
             windowEnabled = false;
+            earlyWakeupInterruptFlag = false;
         }
 
         public long Size => 0x400;
@@ -103,11 +105,25 @@ namespace Antmicro.Renode.Peripherals.Timers
             }, name: "RL")
             .WithReservedBits(12, 20);
 
-            Registers.Status.Define(this)
-            .WithFlag(0, FieldMode.Read, valueProviderCallback: _ => false, name: "PVU")
-            .WithFlag(1, FieldMode.Read, valueProviderCallback: _ => false, name: "RVU")
-            .WithFlag(2, FieldMode.Read, valueProviderCallback: _ => false, name: "WVU")
-            .WithReservedBits(3, 29);
+            if(earlyWakeupOption)
+            {
+                Registers.Status.Define(this)
+                .WithFlag(0, FieldMode.Read, valueProviderCallback: _ => false, name: "PVU")
+                .WithFlag(1, FieldMode.Read, valueProviderCallback: _ => false, name: "RVU")
+                .WithFlag(2, FieldMode.Read, valueProviderCallback: _ => false, name: "WVU")
+                .WithFlag(3, FieldMode.Read, valueProviderCallback: _ => false, name: "EWU")
+                .WithReservedBits(4, 10)
+                .WithFlag(14, FieldMode.Read, valueProviderCallback: _ => earlyWakeupInterruptFlag, name: "EWIF")
+                .WithReservedBits(15, 17);
+            }
+            else
+            {
+                Registers.Status.Define(this)
+                .WithFlag(0, FieldMode.Read, valueProviderCallback: _ => false, name: "PVU")
+                .WithFlag(1, FieldMode.Read, valueProviderCallback: _ => false, name: "RVU")
+                .WithFlag(2, FieldMode.Read, valueProviderCallback: _ => false, name: "WVU")
+                .WithReservedBits(3, 29);
+            }
 
             if(windowOption)
             {
@@ -127,6 +143,22 @@ namespace Antmicro.Renode.Peripherals.Timers
                 }, name: "WIN")
                 .WithReservedBits(12, 20);
             }
+
+            if(earlyWakeupOption)
+            {
+                Registers.EarlyWakeup.Define(this)
+                .WithValueField(0, 12, name: "EWIT")
+                .WithReservedBits(12, 2)
+                .WithFlag(14, FieldMode.Write, writeCallback: (_, value) =>
+                {
+                    if(value)
+                    {
+                        earlyWakeupInterruptFlag = false;
+                    }
+                }, name: "EWIC")
+                .WithFlag(15, name: "EWIE")
+                .WithReservedBits(16, 16);
+            }
         }
 
         private void Reload()
@@ -144,10 +176,12 @@ namespace Antmicro.Renode.Peripherals.Timers
         private uint reloadValue;
         private uint window;
         private bool windowEnabled;
+        private bool earlyWakeupInterruptFlag;
 
         private readonly LimitTimer watchdogTimer;
         private readonly uint defaultPrescaler;
         private readonly bool windowOption;
+        private readonly bool earlyWakeupOption;
 
         private const uint DefaultReloadValue = 0xFFF;
         private const uint DefaultWindow = 0xFFF;
@@ -167,6 +201,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             Reload = 0x8,
             Status = 0xC,
             Window = 0x10,
+            EarlyWakeup = 0x14,
         }
     }
 }

--- a/src/Emulator/Peripherals/Peripherals/UART/STM32F7_USART.cs
+++ b/src/Emulator/Peripherals/Peripherals/UART/STM32F7_USART.cs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2010-2024 Antmicro
+// Copyright (c) 2010-2025 Antmicro
 //
 // This file is licensed under the MIT License.
 // Full license text is available in 'licenses/MIT.txt'.
@@ -16,15 +16,16 @@ using Antmicro.Renode.Time;
 namespace Antmicro.Renode.Peripherals.UART
 {
     [AllowedTranslations(AllowedTranslation.ByteToDoubleWord | AllowedTranslation.WordToDoubleWord)]
-    public sealed class STM32F7_USART : UARTBase, IUARTWithBufferState, IDoubleWordPeripheral, IKnownSize
+    public sealed class STM32F7_USART : UARTBase, IUARTWithBufferState, IDoubleWordPeripheral, IKnownSize, IHasFrequency
     {
-        public STM32F7_USART(IMachine machine, uint frequency, bool lowPowerMode = false) : base(machine)
+        public STM32F7_USART(IMachine machine, uint frequency, bool lowPowerMode = false, bool hasPrescaler = false) : base(machine)
         {
             IRQ = new GPIO();
             ReceiveDmaRequest = new GPIO();
             RegistersCollection = new DoubleWordRegisterCollection(this);
             this.frequency = frequency;
             this.lowPowerMode = lowPowerMode;
+            this.hasPrescaler = hasPrescaler;
             DefineRegisters();
         }
 
@@ -45,6 +46,12 @@ namespace Antmicro.Renode.Peripherals.UART
         public void WriteDoubleWord(long offset, uint value)
         {
             RegistersCollection.Write(offset, value);
+        }
+
+        public ulong Frequency
+        {
+            get => frequency;
+            set { frequency = checked((uint)value); }
         }
 
         public override uint BaudRate => BaudRateMultiplier * frequency / (uint)baudRateDivisor.Value;
@@ -209,6 +216,11 @@ namespace Antmicro.Renode.Peripherals.UART
                     .WithReservedBits(16, 16);
             }
 
+            Registers.GuardTimeAndPrescaler.Define(RegistersCollection)
+                .WithTag("PSC", 0, 8)
+                .WithTag("GT", 8, 8)
+                .WithReservedBits(16, 16);
+
             var request = Registers.Request.Define(RegistersCollection)
                 .WithFlag(1, FieldMode.Write, name: "SBKRQ")
                 .WithFlag(2, FieldMode.Write, name: "MMRQ")
@@ -271,6 +283,13 @@ namespace Antmicro.Renode.Peripherals.UART
                     // reading this register will intentionally return the last written value
                     writeCallback: (_, val) => HandleTransmitData((uint)val), name: "TDR")
                 .WithReservedBits(8, 24);
+
+            if(hasPrescaler)
+            {
+                Registers.Prescaler.Define(RegistersCollection)
+                    .WithTag("PRESCALER", 0, 4)
+                    .WithReservedBits(4, 28);
+            }
 
             if(lowPowerMode)
             {
@@ -434,8 +453,9 @@ namespace Antmicro.Renode.Peripherals.UART
 
         private BufferState bufferState;
 
-        private readonly uint frequency;
+        private uint frequency;
         private readonly bool lowPowerMode;
+        private readonly bool hasPrescaler;
 
         private enum Registers
         {
@@ -443,12 +463,14 @@ namespace Antmicro.Renode.Peripherals.UART
             ControlRegister2   = 0x4,
             ControlRegister3   = 0x8,
             BaudRate           = 0xC,
+            GuardTimeAndPrescaler = 0x10,
             ReceiverTimeout    = 0x14,
             Request            = 0x18,
             InterruptAndStatus = 0x1C,
             InterruptFlagClear = 0x20,
             ReceiveData        = 0x24,
             TransmitData       = 0x28,
+            Prescaler          = 0x2C,
         }
     }
 }


### PR DESCRIPTION
### Related issue

https://github.com/renode/renode/issues/915
https://github.com/renode/renode/pull/949

### Description

**Feature** — adds first-class STM32H5 peripheral models and extends shared models to support the Nucleo-H563ZI board running unmodified CubeMX-generated bare-metal firmware in Renode.

**New peripheral models (5):**

| Model | Category | Purpose |
|---|---|---|
| `STM32H5_PWR` | Miscellaneous | Voltage scaling selection with immediate VOSRDY/ACTVOS mirroring |
| `STM32H5_RCC` | Miscellaneous | Reset & clock controller with oscillator ready-bit mirroring, PLL frequency computation propagated to NVIC, and SW→SWS clock-switch status |
| `STM32H5_FlashController` | MTD | ACR latency/WRHIGHFREQ read-back, dual-key unlock sequence, program (FW-triggered EOP), and sector/bank erase with lock enforcement |
| `STM32H5_ICACHE` | Cache | Instruction cache register interface (EN, CACHEINV self-clear, BSYENDF/FCR flag lifecycle, zero-value monitors) |
| `STM32H5_EXTI` | IRQControllers | Extended interrupt controller with separate rising/falling pending registers, per-port EXTICR mux, IMR-independent pending, and SWIER |

**Extended shared models (4):**

| Model | Change |
|---|---|
| `STM32F7_USART` | Added guard-time register, prescaler register (PRESC), and settable `Frequency` property for baud-rate computation |
| `STM32_RNG` | Added `STM32Series.H5` support: `CONDRST` round-trip, NSCR and HTCR noise-source/health-test registers |
| `STM32_IndependentWatchdog` | Added optional EWCR register gated by `hasPrescaler` and `earlyWakeupOption` constructor parameters |
| `STM32Series` enum | Added `H5` member |

### Usage example

The models are instantiated in the SoC platform description (`platforms/cpus/stm32h563.repl`):

```
pwr: Miscellaneous.STM32H5_PWR @ sysbus 0x44020800

rcc: Miscellaneous.STM32H5_RCC @ sysbus 0x44020C00
    nvic: nvic

flashController: MTD.STM32H5_FlashController @ sysbus 0x40022000
    flash: flash

icache: Cache.STM32H5_ICACHE @ sysbus 0x40030400

iwdg: Timers.STM32_IndependentWatchdog @ sysbus 0x40003000
    frequency: 32000
    hasPrescaler: true
    earlyWakeupOption: true

rng: Miscellaneous.STM32_RNG @ sysbus 0x420C0800
    series: STM32Series.H5
```

A full reproduction repository is available at:
https://github.com/nburek/renode-issue-reproduction-template

### Additional information

**Deliberate `STM32WBA_EXTI` divergence.** The H5 EXTI model (`STM32H5_EXTI`) does **not** extend or share code with `STM32WBA_EXTI` despite similar register layouts. The reason: the WBA model applies the IMR mask to the pending-bit record path, whereas the H5 architecture records pending unconditionally and only gates NVIC delivery on IMR. Merging the two would require restructuring the WBA model's semantics, which is out of scope for this PR. The shared `STM32_EXTICore` helper is left untouched.

**`hasPrescaler` / `earlyWakeupOption` opt-in defaults.** The IWDG extensions (`EWCR` register and the `EWU`/`EWIF` status bits in SR) are gated behind constructor parameters that default to `false`. Existing platforms instantiating `STM32_IndependentWatchdog` are unaffected — only platforms that set `hasPrescaler: true` and/or `earlyWakeupOption: true` in their `.repl` expose the new register. The alternative (always-present EWCR with self-disabling fields) was rejected because H7-era parts do not have this register and would log spurious warnings.

**Documented follow-up items:**

1. **RCC `*ENR`/`*RSTR` register blocks** are implemented as storage only — writing a clock-enable bit preserves the value but does not propagate enable/reset state to the corresponding modelled peripheral instance. Future work: wire each `ENR`/`RSTR` bit to the addressed peripheral so that a clock-gated access is diagnosable and a reset request actually resets that peripheral.

2. **ICACHE** is a register interface over a no-op cache — the `EN` bit is stored, `CACHEINV` self-clears and sets `BSYENDF`, and the hit/miss monitors (`HMONR`/`MMONR`) read zero. Future work: line-level cache storage with access-driven hit and miss counters, and invalidation that occupies emulated time so `BSYF` is observable.
