### PR TITLE
[#951] Fix XilinxGPIOPS to be compatible with ZynqMP

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/XilinxGPIOPS.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/XilinxGPIOPS.cs
@@ -6,6 +6,7 @@
 // Full license text is available in 'licenses/MIT.txt'.
 //
 using Antmicro.Renode.Core;
+using Antmicro.Renode.Exceptions;
 using Antmicro.Renode.Logging;
 using Antmicro.Renode.Peripherals.Bus;
 using Antmicro.Renode.Peripherals.Bus.Wrappers;
@@ -14,12 +15,51 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
 {
     public class XilinxGPIOPS : BaseGPIOPort, IDoubleWordPeripheral, IKnownSize, IHasMappedRegisters
     {
-        public XilinxGPIOPS(IMachine machine, uint numberOfGpioBanks = 4) : base(machine, 54 + 64) //54 MIO + 64 EMIO
+        public XilinxGPIOPS(IMachine machine, string platform = "Zynq") : base(machine, GetNumberOfPins(platform))
         {
+            switch(platform.ToLowerInvariant())
+            {
+            case "zynq":
+                numberOfGpioBanks = 4;
+                portOffsets = new uint[] { 0, 32, 54, 86, 118 };
+                bankType = new GPIOType[] { GPIOType.MIO, GPIOType.MIO, GPIOType.EMIO, GPIOType.EMIO };
+                break;
+            case "zynqmp":
+                // 3 26-bit MIO banks and 3 32-bit EMIO banks
+                numberOfGpioBanks = 6;
+                portOffsets = new uint[] { 0, 26, 52, 78, 110, 142, 174 };
+                bankType = new GPIOType[] { GPIOType.MIO, GPIOType.MIO, GPIOType.MIO, GPIOType.EMIO, GPIOType.EMIO, GPIOType.EMIO };
+                break;
+            case "versal-pmc":
+                numberOfGpioBanks = 4;
+                portOffsets = new uint[] { 0, 26, 52, 84, 116 };
+                bankType = new GPIOType[] { GPIOType.MIO, GPIOType.MIO, GPIOType.EMIO, GPIOType.EMIO };
+                break;
+            case "versal-ps":
+                numberOfGpioBanks = 2;
+                portOffsets = new uint[] { 0, 26, 58 };
+                bankType = new GPIOType[] { GPIOType.MIO, GPIOType.EMIO };
+                break;
+            default:
+                throw new ConstructionException("This platform is not valid for GPIO peripheral XilinxGPIOPS.");
+            }
+            Data = new uint[numberOfGpioBanks];
             portControllers = new GPIOController[numberOfGpioBanks];
+            IRQ = new GPIO(); // NEW - support of IRQs. Per the doc there is 1 interrupt line for all banks
             for(uint i = 0; i < numberOfGpioBanks; i++)
             {
                 portControllers[i] = new GPIOController(this, i);
+            }
+            Reset();
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            for(int i = 0; i < (int)numberOfGpioBanks; i++)
+            {
+                uint level = GetCurrentBankLevel(i);
+                UpdateInterrupts(i, level, level);
             }
         }
 
@@ -34,51 +74,88 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
             }
             switch((RegistersOffsets)offset)
             {
+            // Reading the Maskable Output registers returns the value stored in the Output registers, regardless of
+            // if OutputEnable is true or not, per the documentation
             case RegistersOffsets.MaskableOutputData0Low:
-                return OutputData0 & 0xFFFF;
+                return Data[0] & 0xFFFF;
             case RegistersOffsets.MaskableOutputData0Hi:
-                return OutputData0 >> 16;
+                return Data[0] >> 16;
             case RegistersOffsets.MaskableOutputData1Low:
-                return OutputData1 & 0xFFFF;
+                return Data[1] & 0xFFFF;
             case RegistersOffsets.MaskableOutputData1Hi:
-                return OutputData1 >> 16;
+                return Data[1] >> 16;
             case RegistersOffsets.MaskableOutputData2Low:
-                return OutputData2 & 0xFFFF;
+                if(numberOfGpioBanks > 2) return Data[2] & 0xFFFF;
+                this.WarningLog("Tried to read MaskableOutputData2Low when there are only {0} banks; returning 0.", numberOfGpioBanks);
+                return 0;
             case RegistersOffsets.MaskableOutputData2Hi:
-                return OutputData2 >> 16;
+                if(numberOfGpioBanks > 2) return Data[2] >> 16;
+                this.WarningLog("Tried to read MaskableOutputData2High when there are only {0} banks; returning 0.", numberOfGpioBanks);
+                return 0;
             case RegistersOffsets.MaskableOutputData3Low:
-                return OutputData3 & 0xFFFF;
+                if(numberOfGpioBanks > 3) return Data[3] & 0xFFFF;
+                this.WarningLog("Tried to read MaskableOutputData3Low when there are only {0} banks; returning 0.", numberOfGpioBanks);
+                return 0;
             case RegistersOffsets.MaskableOutputData3Hi:
-                return OutputData3 >> 16;
+                if(numberOfGpioBanks > 3) return Data[3] >> 16;
+                this.WarningLog("Tried to read MaskableOutputData3High when there are only {0} banks; returning 0.", numberOfGpioBanks);
+                return 0;
             case RegistersOffsets.MaskableOutputData4Low:
+                if(numberOfGpioBanks > 4) return Data[4] & 0xFFFF;
+                this.WarningLog("Tried to read MaskableOutputData4Low when there are only {0} banks; returning 0.", numberOfGpioBanks);
+                return 0;
             case RegistersOffsets.MaskableOutputData4Hi:
+                if(numberOfGpioBanks > 4) return Data[4] >> 16;
+                this.WarningLog("Tried to read MaskableOutputData4High when there are only {0} banks; returning 0.", numberOfGpioBanks);
+                return 0;
             case RegistersOffsets.MaskableOutputData5Low:
+                if(numberOfGpioBanks > 5) return Data[5] & 0xFFFF;
+                this.WarningLog("Tried to read MaskableOutputData5Low when there are only {0} banks; returning 0.", numberOfGpioBanks);
+                return 0;
             case RegistersOffsets.MaskableOutputData5Hi:
-                this.WarningLog($"Read from EMIO register at offset 0x{offset:X} ({(RegistersOffsets)offset}) is not supported, returning 0.", offset);
+                if(numberOfGpioBanks > 5) return Data[5] >> 16;
+                this.WarningLog("Tried to read MaskableOutputData5High when there are only {0} banks; returning 0.", numberOfGpioBanks);
                 return 0;
-            case RegistersOffsets.OutputData0:
-                return OutputData0;
-            case RegistersOffsets.OutputData1:
-                return OutputData1;
-            case RegistersOffsets.OutputData2:
-                return OutputData2;
-            case RegistersOffsets.OutputData3:
-                return OutputData3;
-            case RegistersOffsets.OutputData4:
-            case RegistersOffsets.OutputData5:
-                this.WarningLog($"Read from EMIO register at offset 0x{offset:X} ({(RegistersOffsets)offset}) is not supported, returning 0.", offset);
+            case RegistersOffsets.Data_RO0:
+                // If Output Enable is off, data is stored inside the Output register, but not passed to the pins
+                return GetCurrentBankLevel(0);
+            case RegistersOffsets.Data_RO1:
+                return GetCurrentBankLevel(1);
+            case RegistersOffsets.Data_RO2:
+                if(numberOfGpioBanks > 2) return GetCurrentBankLevel(2);
+                this.WarningLog("Tried to read Data_RO2 when there are only {0} banks; returning 0.", numberOfGpioBanks);
                 return 0;
-            case RegistersOffsets.InputData0:
-                return OutputData0;
-            case RegistersOffsets.InputData1:
-                return OutputData1;
-            case RegistersOffsets.InputData2:
-                return OutputData2;
-            case RegistersOffsets.InputData3:
-                return OutputData3;
-            case RegistersOffsets.InputData4:
-            case RegistersOffsets.InputData5:
-                this.WarningLog($"Read from EMIO register at offset 0x{offset:X} ({(RegistersOffsets)offset}) is not supported, returning 0.", offset);
+            case RegistersOffsets.Data_RO3:
+                if(numberOfGpioBanks > 3) return GetCurrentBankLevel(3);
+                this.WarningLog("Tried to read Data_RO3 when there are only {0} banks; returning 0.", numberOfGpioBanks);
+                return 0;
+            case RegistersOffsets.Data_RO4:
+                if(numberOfGpioBanks > 4) return GetCurrentBankLevel(4);
+                this.WarningLog("Tried to read Data_RO4 when there are only {0} banks; returning 0.", numberOfGpioBanks);
+                return 0;
+            case RegistersOffsets.Data_RO5:
+                if(numberOfGpioBanks > 5) return GetCurrentBankLevel(5);
+                this.WarningLog("Tried to read Data_RO5 when there are only {0} banks; returning 0.", numberOfGpioBanks);
+                return 0;
+            case RegistersOffsets.Data0:
+                return Data[0];
+            case RegistersOffsets.Data1:
+                return Data[1];
+            case RegistersOffsets.Data2:
+                if(numberOfGpioBanks > 2) return Data[2];
+                this.WarningLog("Tried to read Data2 when there are only {0} banks; returning 0.", numberOfGpioBanks);
+                return 0;
+            case RegistersOffsets.Data3:
+                if(numberOfGpioBanks > 3) return Data[3];
+                this.WarningLog("Tried to read Data3 when there are only {0} banks; returning 0.", numberOfGpioBanks);
+                return 0;
+            case RegistersOffsets.Data4:
+                if(numberOfGpioBanks > 4) return Data[4];
+                this.WarningLog("Tried to read Data4 when there are only {0} banks; returning 0.", numberOfGpioBanks);
+                return 0;
+            case RegistersOffsets.Data5:
+                if(numberOfGpioBanks > 5) return Data[5];
+                this.WarningLog("Tried to read Data5 when there are only {0} banks; returning 0.", numberOfGpioBanks);
                 return 0;
             default:
                 this.LogUnhandledRead(offset);
@@ -94,87 +171,216 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 portControllers[portNumber].WriteRegister(offset % 0x40, value);
                 return;
             }
+            uint previous, after;
             switch((RegistersOffsets)offset)
             {
             case RegistersOffsets.MaskableOutputData0Low:
-                OutputData0 = (OutputData0 & 0xFFFF0000) | (value & 0xFFFF);
+                previous = GetCurrentBankLevel(0);
+                Data[0] = (Data[0] & 0xFFFF0000) | (value & 0xFFFF);
                 this.DoPinOperation(0, value & 0xFFFF, 0xFFFF0000 | value >> 16);
+                after = GetCurrentBankLevel(0);
+                UpdateInterrupts(0, previous, after);
                 break;
             case RegistersOffsets.MaskableOutputData0Hi:
-                OutputData0 = (OutputData0 & 0x0000FFFF) | (value << 16);
+                previous = GetCurrentBankLevel(0);
+                Data[0] = (Data[0] & 0x0000FFFF) | (value << 16);
                 this.DoPinOperation(0, value & 0xFFFF, 0x0000FFFF | value >> 16);
+                after = GetCurrentBankLevel(0);
+                UpdateInterrupts(0, previous, after);
                 break;
             case RegistersOffsets.MaskableOutputData1Low:
-                OutputData1 = (OutputData1 & 0xFFFF0000) | (value & 0xFFFF);
+                previous = GetCurrentBankLevel(1);
+                Data[1] = (Data[1] & 0xFFFF0000) | (value & 0xFFFF);
                 this.DoPinOperation(1, value & 0xFFFF, 0xFFFF0000 | value >> 16);
+                after = GetCurrentBankLevel(1);
+                UpdateInterrupts(1, previous, after);
                 break;
             case RegistersOffsets.MaskableOutputData1Hi:
-                OutputData1 = (OutputData1 & 0x0000FFFF) | (value << 16);
+                previous = GetCurrentBankLevel(1);
+                Data[1] = (Data[1] & 0x0000FFFF) | (value << 16);
                 this.DoPinOperation(1, value & 0xFFFF, 0x0000FFFF | value >> 16);
+                after = GetCurrentBankLevel(1);
+                UpdateInterrupts(1, previous, after);
                 break;
             case RegistersOffsets.MaskableOutputData2Low:
-                OutputData2 = (OutputData2 & 0xFFFF0000) | (value & 0xFFFF);
-                this.DoPinOperation(2, value & 0xFFFF, 0xFFFF0000 | value >> 16);
+                if(numberOfGpioBanks > 2)
+                {
+                    previous = GetCurrentBankLevel(2);
+                    Data[2] = (Data[2] & 0xFFFF0000) | (value & 0xFFFF);
+                    this.DoPinOperation(2, value & 0xFFFF, 0xFFFF0000 | value >> 16);
+                    after = GetCurrentBankLevel(2);
+                    UpdateInterrupts(2, previous, after);
+                }
                 break;
             case RegistersOffsets.MaskableOutputData2Hi:
-                OutputData2 = (OutputData2 & 0x0000FFFF) | (value << 16);
-                this.DoPinOperation(2, value & 0xFFFF, 0x0000FFFF | value >> 16);
+                if(numberOfGpioBanks > 2)
+                {
+                    previous = GetCurrentBankLevel(2);
+                    Data[2] = (Data[2] & 0x0000FFFF) | (value << 16);
+                    this.DoPinOperation(2, value & 0xFFFF, 0x0000FFFF | value >> 16);
+                    after = GetCurrentBankLevel(2);
+                    UpdateInterrupts(2, previous, after);
+                }
                 break;
             case RegistersOffsets.MaskableOutputData3Low:
-                OutputData3 = (OutputData3 & 0xFFFF0000) | (value & 0xFFFF);
-                this.DoPinOperation(3, value & 0xFFFF, 0xFFFF0000 | value >> 16);
+                if(numberOfGpioBanks > 3)
+                {
+                    previous = GetCurrentBankLevel(3);
+                    Data[3] = (Data[3] & 0xFFFF0000) | (value & 0xFFFF);
+                    this.DoPinOperation(3, value & 0xFFFF, 0xFFFF0000 | value >> 16);
+                    after = GetCurrentBankLevel(3);
+                    UpdateInterrupts(3, previous, after);
+                }
                 break;
             case RegistersOffsets.MaskableOutputData3Hi:
-                OutputData3 = (OutputData3 & 0x0000FFFF) | (value << 16);
-                this.DoPinOperation(3, value & 0xFFFF, 0x0000FFFF | value >> 16);
+                if(numberOfGpioBanks > 3)
+                {
+                    previous = GetCurrentBankLevel(3);
+                    Data[3] = (Data[3] & 0x0000FFFF) | (value << 16);
+                    this.DoPinOperation(3, value & 0xFFFF, 0x0000FFFF | value >> 16);
+                    after = GetCurrentBankLevel(3);
+                    UpdateInterrupts(3, previous, after);
+                }
                 break;
             case RegistersOffsets.MaskableOutputData4Low:
+                if(numberOfGpioBanks > 4)
+                {
+                    previous = GetCurrentBankLevel(4);
+                    Data[4] = (Data[4] & 0xFFFF0000) | (value & 0xFFFF);
+                    this.DoPinOperation(4, value & 0xFFFF, 0xFFFF0000 | value >> 16);
+                    after = GetCurrentBankLevel(4);
+                    UpdateInterrupts(4, previous, after);
+                }
+                break;
             case RegistersOffsets.MaskableOutputData4Hi:
+                if(numberOfGpioBanks > 4)
+                {
+                    previous = GetCurrentBankLevel(4);
+                    Data[4] = (Data[4] & 0x0000FFFF) | (value << 16);
+                    this.DoPinOperation(4, value & 0xFFFF, 0x0000FFFF | value >> 16);
+                    after = GetCurrentBankLevel(4);
+                    UpdateInterrupts(4, previous, after);
+                }
+                break;
             case RegistersOffsets.MaskableOutputData5Low:
+                if(numberOfGpioBanks > 5)
+                {
+                    previous = GetCurrentBankLevel(5);
+                    Data[5] = (Data[5] & 0xFFFF0000) | (value & 0xFFFF);
+                    this.DoPinOperation(5, value & 0xFFFF, 0xFFFF0000 | value >> 16);
+                    after = GetCurrentBankLevel(5);
+                    UpdateInterrupts(5, previous, after);
+                }
+                break;
             case RegistersOffsets.MaskableOutputData5Hi:
-                this.WarningLog($"Write to EMIO register at offset 0x{offset:X} ({(RegistersOffsets)offset}) is not supported", offset);
+                if(numberOfGpioBanks > 5)
+                {
+                    previous = GetCurrentBankLevel(5);
+                    Data[5] = (Data[5] & 0x0000FFFF) | (value << 16);
+                    this.DoPinOperation(5, value & 0xFFFF, 0x0000FFFF | value >> 16);
+                    after = GetCurrentBankLevel(5);
+                    UpdateInterrupts(5, previous, after);
+                }
                 break;
-            case RegistersOffsets.OutputData0:
-                OutputData0 = value;
+            case RegistersOffsets.Data_RO0:
+                this.Log(LogLevel.Warning, "Writing read only register offset: {0:X} value: {1:X}", offset, value);
+                break;
+            case RegistersOffsets.Data_RO1:
+                this.Log(LogLevel.Warning, "Writing read only register offset: {0:X} value: {1:X}", offset, value);
+                break;
+            case RegistersOffsets.Data_RO2:
+                this.Log(LogLevel.Warning, "Writing read only register offset: {0:X} value: {1:X}", offset, value);
+                break;
+            case RegistersOffsets.Data_RO3:
+                this.Log(LogLevel.Warning, "Writing read only register offset: {0:X} value: {1:X}", offset, value);
+                break;
+            case RegistersOffsets.Data_RO4:
+                this.Log(LogLevel.Warning, "Writing read only register offset: {0:X} value: {1:X}", offset, value);
+                break;
+            case RegistersOffsets.Data_RO5:
+                this.Log(LogLevel.Warning, "Writing read only register offset: {0:X} value: {1:X}", offset, value);
+                break;
+            case RegistersOffsets.Data0:
+                previous = GetCurrentBankLevel(0);
+                Data[0] = value;
                 this.DoPinOperation(0, value, 0);
+                after = GetCurrentBankLevel(0);
+                UpdateInterrupts(0, previous, after);
                 break;
-            case RegistersOffsets.OutputData1:
-                OutputData1 = value;
+            case RegistersOffsets.Data1:
+                previous = GetCurrentBankLevel(1);
+                Data[1] = value;
                 this.DoPinOperation(1, value, 0);
+                after = GetCurrentBankLevel(1);
+                UpdateInterrupts(1, previous, after);
                 break;
-            case RegistersOffsets.OutputData2:
-                OutputData2 = value;
-                this.DoPinOperation(2, value, 0);
+            case RegistersOffsets.Data2:
+                if(numberOfGpioBanks > 2)
+                {
+                    previous = GetCurrentBankLevel(2);
+                    Data[2] = value;
+                    this.DoPinOperation(2, value, 0);
+                    after = GetCurrentBankLevel(2);
+                    UpdateInterrupts(2, previous, after);
+                }
                 break;
-            case RegistersOffsets.OutputData3:
-                OutputData2 = value;
-                this.DoPinOperation(2, value, 0);
+            case RegistersOffsets.Data3:
+                if(numberOfGpioBanks > 3)
+                {
+                    previous = GetCurrentBankLevel(3);
+                    Data[3] = value;
+                    this.DoPinOperation(3, value, 0);
+                    after = GetCurrentBankLevel(3);
+                    UpdateInterrupts(3, previous, after);
+                }
                 break;
-            case RegistersOffsets.OutputData4:
-            case RegistersOffsets.OutputData5:
-                this.WarningLog($"Write to EMIO register at offset 0x{offset:X} ({(RegistersOffsets)offset}) is not supported", offset);
+            case RegistersOffsets.Data4:
+                if(numberOfGpioBanks > 4)
+                {
+                    previous = GetCurrentBankLevel(4);
+                    Data[4] = value;
+                    this.DoPinOperation(4, value, 0);
+                    after = GetCurrentBankLevel(4);
+                    UpdateInterrupts(4, previous, after);
+                }
                 break;
-            case RegistersOffsets.InputData0:
-                this.Log(LogLevel.Warning, "Writing read only register offset: {0:X} value: {1:X}", offset, value);
-                break;
-            case RegistersOffsets.InputData1:
-                this.Log(LogLevel.Warning, "Writing read only register offset: {0:X} value: {1:X}", offset, value);
-                break;
-            case RegistersOffsets.InputData2:
-                this.Log(LogLevel.Warning, "Writing read only register offset: {0:X} value: {1:X}", offset, value);
-                break;
-            case RegistersOffsets.InputData3:
-                this.Log(LogLevel.Warning, "Writing read only register offset: {0:X} value: {1:X}", offset, value);
-                break;
-            case RegistersOffsets.InputData4:
-            case RegistersOffsets.InputData5:
-                this.WarningLog($"Write to EMIO register at offset 0x{offset:X} ({(RegistersOffsets)offset}) is not supported", offset);
+            case RegistersOffsets.Data5:
+                if(numberOfGpioBanks > 5)
+                {
+                    previous = GetCurrentBankLevel(5);
+                    Data[5] = value;
+                    this.DoPinOperation(5, value, 0);
+                    after = GetCurrentBankLevel(5);
+                    UpdateInterrupts(5, previous, after);
+                }
                 break;
             default:
                 this.LogUnhandledWrite(offset, value);
                 break;
             }
         }
+
+        public override void OnGPIO(int number, bool value)
+        {
+            this.NoisyLog("OnGPIO: call with GPIO number {0} and value {1}", number, value);
+            // Find the port this pin belongs to
+            int bank, offset;
+            this.PinToBank(number, out bank, out offset);
+            uint previous = GetCurrentBankLevel(bank);
+
+            // Assert this pin is in, not out
+            if((portControllers[bank].OutputEnabled() & (1 << offset)) != 0)
+            {
+                this.Log(LogLevel.Warning, "OnGPIO: Trying to change an out port, skipping");
+                return;
+            }
+            // If the pin is in, update value
+            base.OnGPIO(number, value);
+            uint after = GetCurrentBankLevel(bank);
+            UpdateInterrupts(bank, previous, after);
+        }
+
+        public GPIO IRQ { get; }
 
         public long Size
         {
@@ -184,10 +390,37 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
             }
         }
 
+        uint GetCurrentBankLevel(int bank)
+        {
+            GPIOController portController = portControllers[bank];
+            uint nbOfPins = portOffsets[bank + 1] - portOffsets[bank];
+            uint direction = portController.ReadRegister((long)GPIOController.RegistersOffsets.DirectionMode);
+
+            uint level = Data[bank] & portController.ReadRegister((long)GPIOController.RegistersOffsets.OutputEnable);
+            for(int i = 0; i < nbOfPins; i++)
+            {
+                // We have the output pin level ; let's get the level for input pins as well
+                if((direction & (1u << i)) == 0 && State[(int)portOffsets[bank] + i]) level |= 1u << i;
+            }
+            return level;
+        }
+
+        private static int GetNumberOfPins(string platform)
+        {
+            switch(platform)
+            {
+            case "Zynq": return 118; //54 MIO + 64 EMIO
+            case "ZynqMP": return 174; //78 MIO + 96 EMIO
+            case "Versal-PMC": return 116; // 52 MIO,
+            case "Versal-PS": return 58; // 26 MIO, 
+            default: throw new ConstructionException("This platform is not valid for GPIO peripheral XilinxGPIOPS.");
+            }
+        }
+
         private void DoPinOperation(int portNumber, uint value, uint mask)
         {
-            /* Port 1 is only 22 bit long, while all the others are 32 bit*/
-            var portLength = portNumber == 1 ? 21 : 31;
+            /* Compute port length based on portOffset array (that has been extended with the end of the port range as well) */
+            var portLength = portOffsets[portNumber + 1] - portOffsets[portNumber];
             var outputEnabled = portControllers[portNumber].OutputEnabled();
             for(int i = 0; i < portLength; i++)
             {
@@ -208,18 +441,71 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
             }
         }
 
+        private void PinToBank(int number, out int bank, out int offset)
+        {
+            bank = -1; offset = -1;
+            for(int i = 0; i < 6; i++) // 6 is the max case, will never be reached ; we will use break before that
+            {
+                if(number < portOffsets[i + 1]) { bank = i; break; }
+            }
+            if(bank < 0)
+            {
+                this.Log(LogLevel.Error, "No bank found for GPIO {0}", number);
+                return;
+            }
+
+            offset = number - (int)portOffsets[bank];
+            this.Log(LogLevel.Info, "OnGPIO: GPIO {0} has been calculated to be in bank {1}, offset {2}", number, bank, offset);
+        }
+
+        private void UpdateInterrupts(int bank, uint before, uint after)
+        {
+            this.NoisyLog("UpdateInterrupts: bank {0}, old value {1}, new value {2}", bank, before, after);
+            GPIOController portController = portControllers[bank];
+
+            uint assert_low = ~after & portController.LevelLowInterrupt();
+            uint assert_high = after & portController.LevelHighInterrupt();
+            uint rising_edge = ~before & after & portController.RisingEdgeInterrupt();
+            uint falling_edge = before & ~after & portController.FallingEdgeInterrupt();
+
+            uint interrupt = assert_low | assert_high | rising_edge | falling_edge;
+            if(interrupt != 0)
+            {
+                this.Log(LogLevel.Info, "Conditions for interrupt on bank {0} have been met. Rising interrupt....", bank);
+                this.Log(LogLevel.Noisy, "Before value : {0} ; After value : {1}", before, after);
+                this.Log(LogLevel.Noisy, "Level Low : {0} ; Level High : {1} ; Rising Edge {2}, Falling Edge {3}", assert_low, assert_high, rising_edge, falling_edge);
+
+                portController.SetInterruptStatus(interrupt);
+            }
+            UpdateIRQLine();
+        }
+
+        private void UpdateIRQLine()
+        {
+            // For all banks, check if one of their interrupt lines is set ; that 
+            bool allBankInterrupts = false;
+            for(int i = 0; i < numberOfGpioBanks; i++)
+            {
+                GPIOController control = portControllers[i];
+                if((control.GetInterruptStatus() & control.GetUnmaskedInterrupts()) != 0) allBankInterrupts = true;
+            }
+            IRQ.Set(allBankInterrupts);
+        }
+
         /* Registers */
-        private uint OutputData0;
-        private uint OutputData1;
-        private uint OutputData2;
-        private uint OutputData3;
+        private readonly uint[] Data;
+
+        private readonly uint[] portOffsets;
+        private readonly uint numberOfGpioBanks;
+        private readonly GPIOType[] bankType;
         private readonly RegisterMapper registerMapper = new RegisterMapper(typeof(RegistersOffsets));
-        private readonly uint[] portOffsets = new uint[] { 0, 32, 54, 86 };
 
         private readonly GPIOController[] portControllers;
 
-        /* Common register sets for the all the banks */
-        private class GPIOController
+        /* Common register sets for the all the banks
+         * This is where the interruption parameters are handled
+         */
+        protected class GPIOController
         {
             public GPIOController(XilinxGPIOPS parent, uint bankNumber)
             {
@@ -229,16 +515,54 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
 
             public void WriteRegister(long offset, uint value)
             {
+                uint level;
                 switch((RegistersOffsets)offset)
                 {
                 case RegistersOffsets.DirectionMode:
                     DirectionMode = value;
+                    parentClass.DoPinOperation((int)this.bankNumber, parentClass.Data[this.bankNumber], 0); // Re-run connections on newly output pins
                     break;
                 case RegistersOffsets.OutputEnable:
                     OutputEnable = value;
+                    parentClass.DoPinOperation((int)this.bankNumber, parentClass.Data[this.bankNumber], 0); // Re-run connections on output-enabled pins
+                    break;
+                case RegistersOffsets.InterruptMaskStatus:
+                    parentClass.Log(LogLevel.Warning, "Writing Read-only register, ignored");
+                    break;
+                case RegistersOffsets.InterruptEnable:
+                    InterruptMask &= ~value;
+                    level = parentClass.GetCurrentBankLevel((int)bankNumber);
+                    parentClass.UpdateInterrupts((int)this.bankNumber, level, level);
+                    break;
+                case RegistersOffsets.InterruptDisable:
+                    InterruptMask |= value;
+                    break;
+                case RegistersOffsets.InterruptStatus:
+                    // Write 1 to clear
+                    InterruptStatus &= ~value;
+                    level = parentClass.GetCurrentBankLevel((int)bankNumber);
+                    parentClass.UpdateInterrupts((int)this.bankNumber, level, level);
+                    break;
+                case RegistersOffsets.InterruptType:
+                    parentClass.Log(LogLevel.Noisy, "InterruptType set to 0x{0}", value.ToString("X8"));
+                    InterruptType = value;
+                    level = parentClass.GetCurrentBankLevel((int)bankNumber);
+                    parentClass.UpdateInterrupts((int)this.bankNumber, level, level);
+                    break;
+                case RegistersOffsets.InterruptPolarity:
+                    InterruptPolarity = value;
+                    level = parentClass.GetCurrentBankLevel((int)bankNumber);
+                    parentClass.UpdateInterrupts((int)this.bankNumber, level, level);
+                    break;
+                case RegistersOffsets.InterruptAnyEdgeSensitive:
+                    // Update bits only if InterruptType is set to Edge = 1
+                    // So these should update only of Interrupt Type is 1
+                    InterruptOnAny = value & InterruptType;
+                    level = parentClass.GetCurrentBankLevel((int)bankNumber);
+                    parentClass.UpdateInterrupts((int)this.bankNumber, level, level);
                     break;
                 default:
-                    this.parentClass.LogUnhandledWrite(0x204 + this.bankNumber * 0x40 + offset, value);
+                    this.parentClass.LogUnhandledWrite(0x204 + this.bankNumber * 0x40 + offset, value); //Should be 200 instead of 204?
                     break;
                 }
             }
@@ -251,6 +575,19 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     return DirectionMode;
                 case RegistersOffsets.OutputEnable:
                     return OutputEnable;
+                case RegistersOffsets.InterruptMaskStatus:
+                    return InterruptMask;
+                case RegistersOffsets.InterruptEnable:
+                case RegistersOffsets.InterruptDisable:
+                    parentClass.Log(LogLevel.Warning, "Reading Write-1-to-set register, returning 0"); return 0;
+                case RegistersOffsets.InterruptStatus:
+                    return InterruptStatus;
+                case RegistersOffsets.InterruptType:
+                    return InterruptType;
+                case RegistersOffsets.InterruptPolarity:
+                    return InterruptPolarity;
+                case RegistersOffsets.InterruptAnyEdgeSensitive:
+                    return InterruptOnAny;
                 default:
                     this.parentClass.LogUnhandledRead(0x204 + this.bankNumber * 0x40 + offset);
                     return 0;
@@ -262,33 +599,78 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 return (uint)(DirectionMode & OutputEnable);
             }
 
+            public uint LevelLowInterrupt()
+            {
+                parentClass.Log(LogLevel.Noisy, "Interrupt type is 0x{0:X}, Interrupt polarity is 0x{1:X}, mask is 0x{2:X}", InterruptType, InterruptPolarity, InterruptMask);
+                return (uint)(~InterruptType & ~InterruptPolarity);
+            }
+
+            public uint LevelHighInterrupt()
+            {
+                return (uint)(~InterruptType & InterruptPolarity);
+            }
+
+            public uint RisingEdgeInterrupt()
+            {
+                return (uint)(InterruptType & (InterruptPolarity | InterruptOnAny));
+            }
+
+            public uint FallingEdgeInterrupt()
+            {
+                return (uint)(InterruptType & (~InterruptPolarity | InterruptOnAny));
+            }
+
+            public void SetInterruptStatus(uint status)
+            {
+                InterruptStatus |= status;
+                parentClass.UpdateIRQLine();
+            }
+
+            public uint GetInterruptStatus()
+            {
+                return InterruptStatus;
+            }
+
+            public uint GetUnmaskedInterrupts()
+            {
+                return ~InterruptMask;
+            }
+
             /* Registers */
             private uint DirectionMode = 0x00;
             private uint OutputEnable = 0x00;
+            private uint InterruptMask = 0xFFFFFFFF; // After Linux tests, seems like masked is 0 and 1 is not masked ; all interrupts are masked on reset
+            private uint InterruptStatus = 0x00; // No interrupt has happened on reset
+            private uint InterruptType = 0xFFFFFFFF; // 0 is level-sensitive ; 1 is edge-sensitive
+            private uint InterruptPolarity = 0x00; // O is low / falling-edge sensitive ; 1 is up / rising edge
+            private uint InterruptOnAny = 0x00; // Sensitive on both edges if 1 (polarity is ignored); sensitive on only 1 edge if 0
             private readonly XilinxGPIOPS parentClass;
             private readonly uint bankNumber;
 
-            private enum RegistersOffsets : uint
+            public enum RegistersOffsets : uint
             {
                 DirectionMode = 0x04,
                 OutputEnable = 0x08,
                 InterruptMaskStatus = 0x0C,
                 InterruptEnable = 0x10,
                 InterruptDisable = 0x14,
-                InterruptPolarity = 0x18,
-                InterruptAnyEdgeSensitive = 0x1C
+                InterruptStatus = 0x18,
+                InterruptType = 0x1C,
+                InterruptPolarity = 0x20,
+                InterruptAnyEdgeSensitive = 0x24,
             }
         }
 
-        /* For the future use
-        private uint InputData0;
-        private uint InputData1;
-        private uint InputData2;
-        private uint InputData3;
-        */
+        private enum GPIOType
+        {
+            MIO,
+            EMIO
+        }
+
         /* Offsets */
         private enum RegistersOffsets : uint
         {
+            // Used for partial GPIO within banks writes
             MaskableOutputData0Low = 0x000,
             MaskableOutputData0Hi  = 0x004,
             MaskableOutputData1Low = 0x008,
@@ -302,19 +684,20 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
             MaskableOutputData5Low = 0x028,
             MaskableOutputData5Hi  = 0x02C,
 
-            OutputData0 = 0x040,
-            OutputData1 = 0x044,
-            OutputData2 = 0x048,
-            OutputData3 = 0x04C,
-            OutputData4 = 0x050,
-            OutputData5 = 0x054,
+            // Used for full bank writes
+            Data0 = 0x040,
+            Data1 = 0x044,
+            Data2 = 0x048,
+            Data3 = 0x04C,
+            Data4 = 0x050,
+            Data5 = 0x054,
 
-            InputData0 = 0x060,
-            InputData1 = 0x064,
-            InputData2 = 0x068,
-            InputData3 = 0x06C,
-            InputData4 = 0x070,
-            InputData5 = 0x074,
+            Data_RO0 = 0x060,
+            Data_RO1 = 0x064,
+            Data_RO2 = 0x068,
+            Data_RO3 = 0x06C,
+            Data_RO4 = 0x070,
+            Data_RO5 = 0x074,
 
             DirectionMode0 = 0x204,
             OutputEnable0  = 0x208,


### PR DESCRIPTION
Taken from [Issue 951](https://github.com/renode/renode/issues/951#issue-5009308680).

### Description

Fix the Xilinx GPIOPS Peripheral implementation to be compatible with all processors it is used in & implement IRQs.
Currently this peripheral implementation is adapted only for the Zynq7000 ; I would like to change it to allow compatibility with the two other processors it is used in as well, in particular the Xilinx UltraScale+ ZynqMP, in my case ZCU102.

While some adaptability is currently available in the Xilinx_GPIOPS peripheral implementation (Number of GPIO banks), a lot of the implementation is hard-coded for 4 banks (the Zynq7000 processor implementation), and does not take into account the number of banks specified as parameter. Other issues include:
- The number of pins in each bank varies from one processor to the other, making the "numberOfGPIOBanks" parameter unreliable for proper emulation
- The current peripheral doesn't expose an IRQ line, making it unable to actually raise an interrupt ; futhermore, the interrupt registers aren't actually implemented. This PR fixes that by implementing the interrupt registers and exposing an IRQ line
- The current implementation exposes "inputData" but never actually uses it ; plus, the outputted GPIO data didn't actually match the documentation (the data written in the Output register and the value at which the pins are driven isn't identical because of the Output Enable register controlling it). This PR fixes that.


### Usage example

- Use the peripheral in other processors implementation, including the already supported ZynqMP ZCU102
- Allow for interruptions to be generated by this peripheral and connection to the GIC


### Do you plan to address this issue and file a PR?

Yes ; I already fixed the implementation and am submitting a PR soon.

### Additional information
Note that the implementation that I propose implies modifying the .repl file for all platforms using this peripheral ; if my implementation ends up making it into the master branch, I would gladly take care of that.

### Tests
I created two branches for this PR, one failing without the fix and one succeeding with the fix. I could only expose the GPIO part and couldn't clearly expose why the previous implementation was incorrect for ZynqMP, but this is based on the documentation for ZynqMP.

Here is the link to the Issue Reproduction template: https://github.com/MaelaDebrie/renode-issue-reproduction-template-ls1043a-gic
For some reason, I couldn't create a new fork ; so all of my bug reports and feature request are on the same repo, sorry about that.
- Branch Xilinx_GPIOPS_fail exposes a case where the interruption mechanism doesn't work (no interruption is generated upon raising the GPIO)
- Branch Xilinx_GPIOPS_succeed uses my fixed Renode fork to show the interruption correctly generated.