### PR TITLE
[#956] NRF52840_GPIOTasksEvents resync input state after arming

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/NRF52840_GPIOTasksEvents.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/NRF52840_GPIOTasksEvents.cs
@@ -296,6 +296,14 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 EventPending = false;
             }
 
+            public void Resync()
+            {
+                if(TryGetPin(out var pin))
+                {
+                    CurrentState = pin.InputValue;
+                }
+            }
+
             public Mode Mode { get; set; }
 
             public uint SelectedPin { get; set; }


### PR DESCRIPTION
Resynchronizes CurrentState to the real level of the currently configured pin, without evaluating/raising an event - called whenever the channel is (re)armed so the *next* real transition is judged against a correct baseline instead of a stale default.


For me it is not clear if some test should be written in any form. Since `NRF52840_GPIOTasksEvents.cs` has no tests yet.