### PR TITLE
[#966] STM32_EXTICore: Report signal edges in the matching pending register

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/IRQControllers/STM32WBA_EXTI.cs
+++ b/src/Emulator/Peripherals/Peripherals/IRQControllers/STM32WBA_EXTI.cs
@@ -153,7 +153,7 @@ namespace Antmicro.Renode.Peripherals.IRQControllers
                     var value = state[pinNumber];
                     if(parent.core.CanSetInterruptValue((byte)pinNumber, value, out var _))
                     {
-                        parent.core.UpdatePendingValue((byte)pinNumber, true);
+                        parent.core.UpdatePendingValue((byte)pinNumber, value);
                         parent.Connections[pinNumber].Set(true);
                     }
                 }

--- a/src/Emulator/Peripherals/Peripherals/IRQControllers/STM32_EXTICore.cs
+++ b/src/Emulator/Peripherals/Peripherals/IRQControllers/STM32_EXTICore.cs
@@ -69,17 +69,20 @@ namespace Antmicro.Renode.Peripherals.IRQControllers
         public void UpdatePendingValue(byte bit, bool value)
         {
             IValueRegisterField registerField;
+            // With separate pending registers 'value' is the level the line settled at,
+            // so it selects the register while the pending flag itself is always set.
+            var pending = value;
             if(separateConfigs)
             {
-                var isRaising = (value != true);
-                registerField = isRaising ? PendingRaisingInterrupts : PendingFallingInterrupts;
+                registerField = value ? PendingRaisingInterrupts : PendingFallingInterrupts;
+                pending = true;
             }
             else
             {
                 registerField = PendingInterrupts;
             }
             var reg = registerField.Value;
-            BitHelper.SetBit(ref reg, (byte)bit, value);
+            BitHelper.SetBit(ref reg, (byte)bit, pending);
             registerField.Value = reg;
         }
 


### PR DESCRIPTION
### Related issue

Fixes renode/renode#966

### Description

Bug fix. STM32WBA_EXTI passed a literal true as the pending value, so the edge direction never reached STM32_EXTICore.UpdatePendingValue, which both selected the pending register from that argument and stored it as the pending flag. Rising edges were therefore reported in EXTI_FPR1, while EXTI_RPR1 was never set.
This passes the level the line settled at instead, and uses it only to select the register while setting the pending flag unconditionally. Models without separate pending registers keep storing the value they pass, so STM32F4_EXTI and STM32H7_EXTI are unaffected.

### Usage example

Reproduction repository created from the issue reproduction template: https://github.com/nokia/renode-renode-issue-reproduction-template/tree/stm32-exti-edge-routing
- 24fb1ab without the fix, CI red: https://github.com/nokia/renode-renode-issue-reproduction-template/actions/runs/31713798622
- c47caa8 with the fix, CI green: https://github.com/nokia/renode-renode-issue-reproduction-template/actions/runs/31714577133
The test file is identical in both commits. Two of its four cases drive falling edges, which already behave correctly on master, so they pass in both runs and guard against a fix that only inverts the register selection.

### Additional information

Verified by building Renode with this change and driving EXTI line 0 through GPIO port A pin 0 on the built-in model: a rising edge sets EXTI_RPR1 and leaves EXTI_FPR1 clear, and a falling edge does the reverse.

This is my first contribution to Renode, so I will sign the CLA.