### PR TITLE
[#964] STM32G0DMA: Fix channel enable read-back and memory-to-peripheral transfers

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/DMA/STM32G0DMA.cs
+++ b/src/Emulator/Peripherals/Peripherals/DMA/STM32G0DMA.cs
@@ -349,37 +349,40 @@ namespace Antmicro.Renode.Peripherals.DMA
                 // This value is still valid in memory-to-memory mode, "peripheral" means
                 // "the address specified by the peripheralAddress field" and not necessarily
                 // a peripheral.
+
+                uint toCopy = 0;
+                // In memory-to-memory mode do the whole block, otherwise copy only one data unit
+                if(memoryToMemory.Value)
+                {
+                    toCopy = (uint)dataCount.Value;
+                    dataCount.Value = 0;
+                }
+                else
+                {
+                    toCopy = Math.Max((uint)SizeToType(memoryTransferType.Value),
+                        (uint)SizeToType(peripheralTransferType.Value));
+                    dataCount.Value -= 1;
+                }
+
                 if(transferDirection.Value == TransferDirection.PeripheralToMemory)
                 {
-                    var toCopy = (uint)dataCount.Value;
-                    // In peripheral-to-memory mode, only copy one data unit. Otherwise, do the whole block.
-                    if(!memoryToMemory.Value)
-                    {
-                        toCopy = Math.Max((uint)SizeToType(memoryTransferType.Value),
-                            (uint)SizeToType(peripheralTransferType.Value));
-                        dataCount.Value -= 1;
-                    }
-                    else
-                    {
-                        dataCount.Value = 0;
-                    }
                     var response = IssueCopy(currentPeripheralAddress, currentMemoryAddress, toCopy,
                         peripheralIncrementMode.Value, memoryIncrementMode.Value, peripheralTransferType.Value,
                         memoryTransferType.Value);
                     currentPeripheralAddress = response.ReadAddress.Value;
                     currentMemoryAddress = response.WriteAddress.Value;
-                    HalfTransfer = dataCount.Value <= originalDataCount / 2;
-                    TransferComplete = dataCount.Value == 0;
                 }
-                else // 1-bit field, so we handle both possible values
+                else
                 {
-                    IssueCopy(memoryAddress.Value, peripheralAddress.Value, (uint)dataCount.Value,
-                        memoryIncrementMode.Value, peripheralIncrementMode.Value, memoryTransferType.Value,
-                        peripheralTransferType.Value);
-                    dataCount.Value = 0;
-                    HalfTransfer = true;
-                    TransferComplete = true;
+                    var response = IssueCopy(currentMemoryAddress, currentPeripheralAddress, toCopy,
+                        memoryIncrementMode.Value, peripheralIncrementMode.Value,
+                        memoryTransferType.Value, peripheralTransferType.Value);
+
+                    currentMemoryAddress = response.ReadAddress.Value;
+                    currentPeripheralAddress = response.WriteAddress.Value;
                 }
+                HalfTransfer = dataCount.Value <= originalDataCount / 2;
+                TransferComplete = dataCount.Value == 0;
 
                 // Loop around if circular mode is enabled
                 if(circularMode.Value && !memoryToMemory.Value && dataCount.Value == 0)

--- a/src/Emulator/Peripherals/Peripherals/DMA/STM32G0DMA.cs
+++ b/src/Emulator/Peripherals/Peripherals/DMA/STM32G0DMA.cs
@@ -232,12 +232,18 @@ namespace Antmicro.Renode.Peripherals.DMA
                             {
                                 return;
                             }
-                            if(memoryToMemory.Value || transferDirection.Value == TransferDirection.MemoryToPeripheral)
+                            if(memoryToMemory.Value)
                             {
                                 DoTransfer();
                             }
-                        },
-                        valueProviderCallback: _ => false, name: "Channel enable (EN)")
+                            else
+                            {
+                                if(this.parent.Connections[channelNumber].IsSet)
+                                {
+                                    TryTriggerTransfer();
+                                }
+                            }
+                        }, name: "Channel enable (EN)")
                     .WithFlag(1, out transferCompleteInterruptEnable, name: "Transfer complete interrupt enable (TCIE)")
                     .WithFlag(2, out halfTransferInterruptEnable, name: "Half transfer interrupt enable (HTIE)")
                     .WithTag("Transfer error interrupt enable (TEIE)", 3, 1)


### PR DESCRIPTION
### Related issue

Fixes renode/renode#964

### Description

Bug fix, covering the two defects reported in the issue, one commit each.

The channel enable bit was forced to read back as 0 by a value provider, so software that enables a channel and then polls CCR never sees it running. Enabling a memory-to-peripheral channel also transferred the whole block immediately, although such channels move data on request. Only memory-to-memory channels transfer on enable now; the others start from the request line, and are triggered on enable only if that line is already set.
Memory-to-peripheral transfers copied CNDTR bytes in a single operation, took the addresses from the register fields rather than the running ones, and then marked the channel complete. One request therefore moved the whole block as if CNDTR counted bytes, and every later request was ignored. They now copy one data unit sized by the wider of the two transfer types and advance the running addresses, as the peripheral-to-memory path already does, so the unit count and the half and complete flags are maintained the same way in both directions.

### Usage example

Two branches in a repository created from the issue reproduction template, one per defect. The second is stacked on the first, so its runs also keep the channel enable test green.

Channel enable read-back: https://github.com/nokia/renode-renode-issue-reproduction-template/tree/stm32g0-dma-channel-enable
- 6703774 without the fix, CI red: https://github.com/nokia/renode-renode-issue-reproduction-template/actions/runs/31432383788
- 3e3ee42 with the fix, CI green: https://github.com/nokia/renode-renode-issue-reproduction-template/actions/runs/31432488037

Memory-to-peripheral transfers: https://github.com/nokia/renode-renode-issue-reproduction-template/tree/stm32g0-dma-mem2periph
- 5b7af9e without the fix, CI red: https://github.com/nokia/renode-renode-issue-reproduction-template/actions/runs/31432496179
- a67d7cb with the fix, CI green: https://github.com/nokia/renode-renode-issue-reproduction-template/actions/runs/31432621869
- 
### Additional information

Verified by building Renode with both commits and driving the built-in model over the system bus: CCR1 reads back 0x00000AD1 after channel 1 is enabled, and four peripheral requests on a four-unit 32-bit memory-to-peripheral channel copy all four words.
