### PR TITLE
[#789] GenericSpiNandFlash: Add generic SPI-NAND flash model

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/SPI/GenericSpiNandFlash.cs
+++ b/src/Emulator/Peripherals/Peripherals/SPI/GenericSpiNandFlash.cs
@@ -1,0 +1,543 @@
+//
+// Copyright (c) 2010-2026 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using System.Collections.Generic;
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Exceptions;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Memory;
+using Antmicro.Renode.Utilities;
+
+namespace Antmicro.Renode.Peripherals.SPI
+{
+    public class GenericSpiNandFlash : ISPIPeripheral, IProvidesRegisterCollection<ByteRegisterCollection>, IGPIOReceiver
+    {
+        public GenericSpiNandFlash(
+            MappedMemory underlyingMemory = null,
+            uint pageSize = DefaultPageSize,
+            uint spareSize = DefaultSpareSize,
+            uint pagesPerBlock = DefaultPagesPerBlock,
+            uint blocksCount = DefaultBlocksCount,
+            byte manufacturerId = DefaultManufacturerId,
+            ushort deviceId = DefaultDeviceId)
+        {
+            this.pageSize = pageSize;
+            this.spareSize = spareSize;
+            this.pagesPerBlock = pagesPerBlock;
+            this.blocksCount = blocksCount;
+            this.manufacturerId = manufacturerId;
+            this.deviceId = deviceId;
+            this.underlyingMemory = underlyingMemory;
+
+            if(deviceId > 0xFF)
+            {
+                idBytes = new byte[] { manufacturerId, (byte)(deviceId >> 8), (byte)(deviceId & 0xFF) };
+            }
+            else
+            {
+                idBytes = new byte[] { manufacturerId, (byte)deviceId };
+            }
+
+            var rawPageSize = (int)(pageSize + spareSize);
+            pageBuffer = new byte[rawPageSize];
+            Array.Fill(pageBuffer, EmptySegment);
+
+            long totalCapacity = (long)blocksCount * pagesPerBlock * rawPageSize;
+            if(underlyingMemory != null)
+            {
+                if(underlyingMemory.Size < totalCapacity)
+                {
+                    throw new ConstructionException($"Underlying memory size (0x{underlyingMemory.Size:X}) is smaller than required SPI-NAND capacity (0x{totalCapacity:X})");
+                }
+                underlyingMemory.ResetByte = EmptySegment;
+            }
+            else
+            {
+                flashMemory = new byte[totalCapacity];
+                Array.Fill(flashMemory, EmptySegment);
+            }
+
+            addressBuffer = new List<byte>();
+            RegistersCollection = new ByteRegisterCollection(this);
+            DefineRegisters();
+            Reset();
+        }
+
+        public void Reset()
+        {
+            RegistersCollection.Reset();
+            state = State.Idle;
+            readIdIndex = 0;
+            currentColumnAddress = 0;
+            featureRegisterAddress = 0;
+            addressBuffer.Clear();
+            Array.Fill(pageBuffer, EmptySegment);
+        }
+
+        public byte Transmit(byte data)
+        {
+            this.Log(LogLevel.Noisy, "Transmitting data 0x{0:X2}, current state: {1}", data, state);
+            byte result = 0;
+
+            switch(state)
+            {
+            case State.Idle:
+                result = HandleIdleCommand((Command)data);
+                break;
+
+            case State.ReadIdDummy:
+                state = State.ReadIdData;
+                readIdIndex = 0;
+                result = 0;
+                break;
+
+            case State.ReadIdData:
+                result = idBytes[readIdIndex];
+                readIdIndex = (readIdIndex + 1) % idBytes.Length;
+                break;
+
+            case State.GetFeatureAddress:
+                featureRegisterAddress = data;
+                state = State.GetFeatureData;
+                result = 0;
+                break;
+
+            case State.GetFeatureData:
+                result = RegistersCollection.Read(featureRegisterAddress);
+                break;
+
+            case State.SetFeatureAddress:
+                featureRegisterAddress = data;
+                state = State.SetFeatureData;
+                result = 0;
+                break;
+
+            case State.SetFeatureData:
+                RegistersCollection.Write(featureRegisterAddress, data);
+                this.Log(LogLevel.Noisy, "Set feature 0x{0:X2} = 0x{1:X2}", featureRegisterAddress, data);
+                state = State.Idle;
+                result = 0;
+                break;
+
+            case State.PageReadAddress:
+                addressBuffer.Add(data);
+                if(addressBuffer.Count == RowAddressByteCount)
+                {
+                    uint rowAddress = ParseRowAddress();
+                    ExecutePageRead(rowAddress);
+                    state = State.Idle;
+                }
+                result = 0;
+                break;
+
+            case State.ReadCacheAddress:
+                addressBuffer.Add(data);
+                if(addressBuffer.Count == ColumnAddressByteCount)
+                {
+                    currentColumnAddress = (uint)((addressBuffer[0] << 8) | addressBuffer[1]) % (uint)pageBuffer.Length;
+                    state = State.ReadCacheDummy;
+                }
+                result = 0;
+                break;
+
+            case State.ReadCacheDummy:
+                state = State.ReadCacheData;
+                result = 0;
+                break;
+
+            case State.ReadCacheData:
+                result = pageBuffer[currentColumnAddress];
+                currentColumnAddress = (currentColumnAddress + 1) % (uint)pageBuffer.Length;
+                break;
+
+            case State.ProgramLoadAddress:
+                addressBuffer.Add(data);
+                if(addressBuffer.Count == ColumnAddressByteCount)
+                {
+                    currentColumnAddress = (uint)((addressBuffer[0] << 8) | addressBuffer[1]) % (uint)pageBuffer.Length;
+                    if(!isRandomProgramLoad)
+                    {
+                        Array.Fill(pageBuffer, EmptySegment);
+                    }
+                    state = State.ProgramLoadData;
+                }
+                result = 0;
+                break;
+
+            case State.ProgramLoadData:
+                pageBuffer[currentColumnAddress] = data;
+                currentColumnAddress = (currentColumnAddress + 1) % (uint)pageBuffer.Length;
+                result = 0;
+                break;
+
+            case State.ProgramExecuteAddress:
+                addressBuffer.Add(data);
+                if(addressBuffer.Count == RowAddressByteCount)
+                {
+                    uint rowAddress = ParseRowAddress();
+                    ExecuteProgram(rowAddress);
+                    state = State.Idle;
+                }
+                result = 0;
+                break;
+
+            case State.BlockEraseAddress:
+                addressBuffer.Add(data);
+                if(addressBuffer.Count == RowAddressByteCount)
+                {
+                    uint rowAddress = ParseRowAddress();
+                    ExecuteBlockErase(rowAddress);
+                    state = State.Idle;
+                }
+                result = 0;
+                break;
+
+            default:
+                this.Log(LogLevel.Error, "Received byte 0x{0:X2} in unexpected state: {1}", data, state);
+                break;
+            }
+
+            return result;
+        }
+
+        public void FinishTransmission()
+        {
+            this.Log(LogLevel.Noisy, "Chip Select deasserted. Finishing transmission.");
+            state = State.Idle;
+            addressBuffer.Clear();
+        }
+
+        public void OnGPIO(int number, bool value)
+        {
+            if(number == 0 && value)
+            {
+                FinishTransmission();
+            }
+        }
+
+        public ByteRegisterCollection RegistersCollection { get; }
+
+        public uint PageSize => pageSize;
+        public uint SpareSize => spareSize;
+        public uint PagesPerBlock => pagesPerBlock;
+        public uint BlocksCount => blocksCount;
+        public byte ManufacturerId => manufacturerId;
+        public ushort DeviceId => deviceId;
+        public MappedMemory UnderlyingMemory => underlyingMemory;
+        public byte[] PageBuffer => pageBuffer;
+
+        private byte HandleIdleCommand(Command command)
+        {
+            switch(command)
+            {
+            case Command.Reset:
+                Reset();
+                break;
+
+            case Command.ReadId:
+                state = State.ReadIdDummy;
+                readIdIndex = 0;
+                break;
+
+            case Command.WriteEnable:
+                writeEnableLatch.Value = true;
+                this.Log(LogLevel.Noisy, "Write enabled (WEL = 1)");
+                break;
+
+            case Command.WriteDisable:
+                writeEnableLatch.Value = false;
+                this.Log(LogLevel.Noisy, "Write disabled (WEL = 0)");
+                break;
+
+            case Command.GetFeature:
+                state = State.GetFeatureAddress;
+                break;
+
+            case Command.SetFeature:
+                state = State.SetFeatureAddress;
+                break;
+
+            case Command.PageRead:
+                addressBuffer.Clear();
+                state = State.PageReadAddress;
+                break;
+
+            case Command.ReadFromCache:
+            case Command.FastReadFromCache:
+            case Command.ReadFromCacheDual:
+            case Command.ReadFromCacheQuad:
+                addressBuffer.Clear();
+                state = State.ReadCacheAddress;
+                break;
+
+            case Command.ProgramLoad:
+                addressBuffer.Clear();
+                isRandomProgramLoad = false;
+                state = State.ProgramLoadAddress;
+                break;
+
+            case Command.ProgramLoadRandom:
+                addressBuffer.Clear();
+                isRandomProgramLoad = true;
+                state = State.ProgramLoadAddress;
+                break;
+
+            case Command.ProgramExecute:
+                addressBuffer.Clear();
+                state = State.ProgramExecuteAddress;
+                break;
+
+            case Command.BlockErase:
+                addressBuffer.Clear();
+                state = State.BlockEraseAddress;
+                break;
+
+            default:
+                this.Log(LogLevel.Warning, "Unsupported SPI-NAND command: 0x{0:X2}", (byte)command);
+                break;
+            }
+
+            return 0;
+        }
+
+        private uint ParseRowAddress()
+        {
+            // Row Address is 24 bits in standard SPI-NAND command framing:
+            // On 1Gb devices, addressBuffer[0] is dummy (0x00).
+            // On 2Gb/4Gb devices (e.g. Alliance Memory AS5F14G04SND, Winbond W25N02GV/W25N04GV),
+            // the lower bits of addressBuffer[0] carry upper page/row address bits RA16-RA19.
+            return (uint)(((addressBuffer[0] & 0x0F) << 16) | (addressBuffer[1] << 8) | addressBuffer[2]);
+        }
+
+        private void ExecutePageRead(uint rowAddress)
+        {
+            var rawPageSize = (int)(pageSize + spareSize);
+            var totalPages = blocksCount * pagesPerBlock;
+            if(rowAddress >= totalPages)
+            {
+                this.Log(LogLevel.Error, "PageRead row address out of bounds: 0x{0:X} (max: 0x{1:X})", rowAddress, totalPages);
+                return;
+            }
+
+            long offset = (long)rowAddress * rawPageSize;
+            ReadFlashBytes(offset, pageBuffer, 0, rawPageSize);
+            eccStatus.Value = 0; // ECC clean
+            this.Log(LogLevel.Noisy, "Loaded page 0x{0:X} (offset 0x{1:X}) into page buffer", rowAddress, offset);
+        }
+
+        private void ExecuteProgram(uint rowAddress)
+        {
+            if(!writeEnableLatch.Value)
+            {
+                this.Log(LogLevel.Warning, "Attempted to Program Execute while write is disabled (WEL = 0)");
+                programFail.Value = true;
+                return;
+            }
+
+            var rawPageSize = (int)(pageSize + spareSize);
+            var totalPages = blocksCount * pagesPerBlock;
+            if(rowAddress >= totalPages)
+            {
+                this.Log(LogLevel.Error, "ProgramExecute row address out of bounds: 0x{0:X} (max: 0x{1:X})", rowAddress, totalPages);
+                programFail.Value = true;
+                writeEnableLatch.Value = false;
+                return;
+            }
+
+            long offset = (long)rowAddress * rawPageSize;
+            WriteFlashBytes(offset, pageBuffer, 0, rawPageSize);
+            programFail.Value = false;
+            writeEnableLatch.Value = false;
+            this.Log(LogLevel.Noisy, "Programmed page 0x{0:X} (offset 0x{1:X}) from page buffer", rowAddress, offset);
+        }
+
+        private void ExecuteBlockErase(uint rowAddress)
+        {
+            if(!writeEnableLatch.Value)
+            {
+                this.Log(LogLevel.Warning, "Attempted Block Erase while write is disabled (WEL = 0)");
+                eraseFail.Value = true;
+                return;
+            }
+
+            var rawPageSize = (int)(pageSize + spareSize);
+            var blockSize = (int)(pagesPerBlock * rawPageSize);
+            uint blockIndex = rowAddress / pagesPerBlock;
+            if(blockIndex >= blocksCount)
+            {
+                this.Log(LogLevel.Error, "BlockErase block index out of bounds: 0x{0:X} (max: 0x{1:X})", blockIndex, blocksCount);
+                eraseFail.Value = true;
+                writeEnableLatch.Value = false;
+                return;
+            }
+
+            long offset = (long)blockIndex * blockSize;
+            FillFlashRange(offset, blockSize, EmptySegment);
+            eraseFail.Value = false;
+            writeEnableLatch.Value = false;
+            this.Log(LogLevel.Noisy, "Erased block {0} (offset 0x{1:X}, size 0x{2:X})", blockIndex, offset, blockSize);
+        }
+
+        private void ReadFlashBytes(long address, byte[] destination, int offset, int count)
+        {
+            if(underlyingMemory != null)
+            {
+                underlyingMemory.ReadBytes(address, count, destination, offset);
+            }
+            else
+            {
+                Buffer.BlockCopy(flashMemory, (int)address, destination, offset, count);
+            }
+        }
+
+        private void WriteFlashBytes(long address, byte[] source, int offset, int count)
+        {
+            if(underlyingMemory != null)
+            {
+                underlyingMemory.WriteBytes(address, source, offset, count);
+            }
+            else
+            {
+                Buffer.BlockCopy(source, offset, flashMemory, (int)address, count);
+            }
+        }
+
+        private void FillFlashRange(long address, int count, byte value)
+        {
+            if(underlyingMemory != null)
+            {
+                underlyingMemory.SetRange(address, count, value);
+            }
+            else
+            {
+                Array.Fill(flashMemory, value, (int)address, count);
+            }
+        }
+
+        private void DefineRegisters()
+        {
+            RegisterType.BlockLock.Define(this, 0x38)
+                .WithFlag(1, out statusRegisterProtect1, name: "SRP1")
+                .WithFlag(2, out writeProtectEnable, name: "WP_E")
+                .WithValueField(3, 4, out blockProtectBits, name: "BP0-BP3")
+                .WithFlag(7, out statusRegisterProtect0, name: "SRP0");
+
+            RegisterType.Config.Define(this, 0x18)
+                .WithFlag(0, name: "CFG0")
+                .WithFlag(1, out quadEnable, name: "QE")
+                .WithReservedBits(2, 2)
+                .WithFlag(4, out eccEnable, name: "ECC_EN")
+                .WithReservedBits(5, 1)
+                .WithFlag(6, name: "OTP_EN")
+                .WithFlag(7, name: "OTP_PRT");
+
+            RegisterType.Status.Define(this, 0x00)
+                .WithFlag(0, out operationInProgress, FieldMode.Read, name: "OIP")
+                .WithFlag(1, out writeEnableLatch, FieldMode.Read | FieldMode.Write, name: "WEL")
+                .WithFlag(2, out eraseFail, FieldMode.Read | FieldMode.Write, name: "E_FAIL")
+                .WithFlag(3, out programFail, FieldMode.Read | FieldMode.Write, name: "P_FAIL")
+                .WithValueField(4, 2, out eccStatus, FieldMode.Read, name: "ECCS")
+                .WithReservedBits(6, 2);
+
+            RegisterType.DieSelect.Define(this, 0x00)
+                .WithReservedBits(0, 6)
+                .WithFlag(6, out dieSelect, name: "DS0")
+                .WithReservedBits(7, 1);
+        }
+
+        private State state;
+        private int readIdIndex;
+        private uint currentColumnAddress;
+        private byte featureRegisterAddress;
+        private bool isRandomProgramLoad;
+
+        private readonly byte[] idBytes;
+        private readonly byte[] pageBuffer;
+        private readonly byte[] flashMemory;
+        private readonly MappedMemory underlyingMemory;
+        private readonly List<byte> addressBuffer;
+
+        private readonly uint pageSize;
+        private readonly uint spareSize;
+        private readonly uint pagesPerBlock;
+        private readonly uint blocksCount;
+        private readonly byte manufacturerId;
+        private readonly ushort deviceId;
+
+        private IFlagRegisterField statusRegisterProtect0;
+        private IFlagRegisterField statusRegisterProtect1;
+        private IFlagRegisterField writeProtectEnable;
+        private IValueRegisterField blockProtectBits;
+        private IFlagRegisterField quadEnable;
+        private IFlagRegisterField eccEnable;
+        private IFlagRegisterField operationInProgress;
+        private IFlagRegisterField writeEnableLatch;
+        private IFlagRegisterField eraseFail;
+        private IFlagRegisterField programFail;
+        private IValueRegisterField eccStatus;
+        private IFlagRegisterField dieSelect;
+
+        private const uint DefaultPageSize = 2048;
+        private const uint DefaultSpareSize = 64;
+        private const uint DefaultPagesPerBlock = 64;
+        private const uint DefaultBlocksCount = 1024;
+        private const byte DefaultManufacturerId = 0x52; // Alliance Memory
+        private const ushort DefaultDeviceId = 0x24;    // AS5F14G04SND
+
+        private const int ColumnAddressByteCount = 2;
+        private const int RowAddressByteCount = 3; // 1 dummy byte + 2 row address bytes
+        private const byte EmptySegment = 0xFF;
+
+        public enum RegisterType : byte
+        {
+            BlockLock = 0xA0,
+            Config = 0xB0,
+            Status = 0xC0,
+            DieSelect = 0xD0
+        }
+
+        private enum State
+        {
+            Idle,
+            ReadIdDummy,
+            ReadIdData,
+            GetFeatureAddress,
+            GetFeatureData,
+            SetFeatureAddress,
+            SetFeatureData,
+            PageReadAddress,
+            ReadCacheAddress,
+            ReadCacheDummy,
+            ReadCacheData,
+            ProgramLoadAddress,
+            ProgramLoadData,
+            ProgramExecuteAddress,
+            BlockEraseAddress,
+        }
+
+        private enum Command : byte
+        {
+            Reset = 0xFF,
+            ReadId = 0x9F,
+            WriteEnable = 0x06,
+            WriteDisable = 0x04,
+            GetFeature = 0x0F,
+            SetFeature = 0x1F,
+            PageRead = 0x13,
+            ReadFromCache = 0x03,
+            FastReadFromCache = 0x0B,
+            ReadFromCacheDual = 0x3B,
+            ReadFromCacheQuad = 0x6B,
+            ProgramLoad = 0x02,
+            ProgramLoadRandom = 0x84,
+            ProgramExecute = 0x10,
+            BlockErase = 0xD8,
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Test/PeripheralsTests/GenericSpiNandFlashTests.cs
+++ b/src/Emulator/Peripherals/Test/PeripheralsTests/GenericSpiNandFlashTests.cs
@@ -1,0 +1,298 @@
+//
+// Copyright (c) 2010-2026 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using Antmicro.Renode.Peripherals.SPI;
+using NUnit.Framework;
+
+namespace Antmicro.Renode.PeripheralsTests
+{
+    [TestFixture]
+    public class GenericSpiNandFlashTests
+    {
+        [Test]
+        public void ShouldReadDefaultJedecId()
+        {
+            var flash = new GenericSpiNandFlash();
+            var id = ReadId(flash, 2);
+            Assert.AreEqual(0x52, id[0], "Manufacturer ID should match Alliance Memory default (0x52)");
+            Assert.AreEqual(0x24, id[1], "Device ID should match AS5F14G04SND default (0x24)");
+        }
+
+        [Test]
+        public void ShouldReadCustom16BitJedecId()
+        {
+            var flash = new GenericSpiNandFlash(manufacturerId: 0xEF, deviceId: 0xAA21);
+            var id = ReadId(flash, 3);
+            Assert.AreEqual(0xEF, id[0], "Manufacturer ID should match Winbond (0xEF)");
+            Assert.AreEqual(0xAA, id[1], "Device ID MSB should match (0xAA)");
+            Assert.AreEqual(0x21, id[2], "Device ID LSB should match (0x21)");
+        }
+
+        [Test]
+        public void ShouldControlWriteEnableLatch()
+        {
+            var flash = new GenericSpiNandFlash();
+            var status = GetFeature(flash, (byte)GenericSpiNandFlash.RegisterType.Status);
+            Assert.AreEqual(0, status & 0x02, "WEL bit should be 0 initially");
+
+            WriteEnable(flash);
+            status = GetFeature(flash, (byte)GenericSpiNandFlash.RegisterType.Status);
+            Assert.AreEqual(0x02, status & 0x02, "WEL bit should be 1 after Write Enable");
+
+            WriteDisable(flash);
+            status = GetFeature(flash, (byte)GenericSpiNandFlash.RegisterType.Status);
+            Assert.AreEqual(0, status & 0x02, "WEL bit should be 0 after Write Disable");
+        }
+
+        [Test]
+        public void ShouldGetAndSetFeatureRegisters()
+        {
+            var flash = new GenericSpiNandFlash();
+            // Test Configuration register (0xB0)
+            SetFeature(flash, (byte)GenericSpiNandFlash.RegisterType.Config, 0x1A);
+            var config = GetFeature(flash, (byte)GenericSpiNandFlash.RegisterType.Config);
+            Assert.AreEqual(0x1A, config & 0x1A, "Configuration register should reflect written bits");
+
+            // Test Block Lock register (0xA0)
+            SetFeature(flash, (byte)GenericSpiNandFlash.RegisterType.BlockLock, 0x00);
+            var blockLock = GetFeature(flash, (byte)GenericSpiNandFlash.RegisterType.BlockLock);
+            Assert.AreEqual(0x00, blockLock, "Block Lock register should be unlocked");
+        }
+
+        [Test]
+        public void ShouldProgramAndReadBackPage()
+        {
+            var flash = new GenericSpiNandFlash();
+            var testData = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0x42, 0x13, 0x37, 0xAA };
+
+            WriteEnable(flash);
+            ProgramPage(flash, rowAddress: 0x0005, columnAddress: 0x0000, testData);
+
+            var readBack = ReadPage(flash, rowAddress: 0x0005, columnAddress: 0x0000, testData.Length);
+            CollectionAssert.AreEqual(testData, readBack, "Read back data should match programmed data");
+        }
+
+        [Test]
+        public void ShouldSupportRandomProgramLoad()
+        {
+            var flash = new GenericSpiNandFlash();
+            var baseData = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+            var randomPatch = new byte[] { 0xAA, 0xBB };
+
+            // Program Load (0x02) base data at offset 0
+            flash.Transmit(0x02);
+            flash.Transmit(0x00);
+            flash.Transmit(0x00);
+            for(int i = 0; i < baseData.Length; i++)
+            {
+                flash.Transmit(baseData[i]);
+            }
+            flash.FinishTransmission();
+
+            // Program Load Random (0x84) patch data at offset 2
+            flash.Transmit(0x84);
+            flash.Transmit(0x00);
+            flash.Transmit(0x02);
+            for(int i = 0; i < randomPatch.Length; i++)
+            {
+                flash.Transmit(randomPatch[i]);
+            }
+            flash.FinishTransmission();
+
+            // Commit to flash
+            WriteEnable(flash);
+            flash.Transmit(0x10);
+            flash.Transmit(0x00);
+            flash.Transmit(0x00);
+            flash.Transmit(0x01);
+            flash.FinishTransmission();
+
+            // Read back
+            var readBack = ReadPage(flash, rowAddress: 0x0001, columnAddress: 0x0000, 6);
+            var expected = new byte[] { 0x01, 0x02, 0xAA, 0xBB, 0x05, 0x06 };
+            CollectionAssert.AreEqual(expected, readBack, "Random program load should overwrite targeted columns without resetting buffer");
+        }
+
+        [Test]
+        public void ShouldRejectProgramExecuteWithoutWriteEnable()
+        {
+            var flash = new GenericSpiNandFlash();
+            var testData = new byte[] { 0x11, 0x22, 0x33, 0x44 };
+
+            // Do NOT call WriteEnable
+            ProgramPage(flash, rowAddress: 0x0002, columnAddress: 0x0000, testData);
+
+            var status = GetFeature(flash, (byte)GenericSpiNandFlash.RegisterType.Status);
+            Assert.AreEqual(0x08, status & 0x08, "P_FAIL bit (bit 3) should be set on write without WEL");
+
+            var readBack = ReadPage(flash, rowAddress: 0x0002, columnAddress: 0x0000, testData.Length);
+            var expectedEmpty = new byte[] { 0xFF, 0xFF, 0xFF, 0xFF };
+            CollectionAssert.AreEqual(expectedEmpty, readBack, "Flash page should remain erased (0xFF)");
+        }
+
+        [Test]
+        public void ShouldEraseBlock()
+        {
+            var flash = new GenericSpiNandFlash();
+            var testData = new byte[] { 0x12, 0x34, 0x56, 0x78 };
+
+            WriteEnable(flash);
+            ProgramPage(flash, rowAddress: 0x0040, columnAddress: 0x0000, testData);
+
+            var beforeErase = ReadPage(flash, rowAddress: 0x0040, columnAddress: 0x0000, testData.Length);
+            CollectionAssert.AreEqual(testData, beforeErase);
+
+            WriteEnable(flash);
+            BlockErase(flash, rowAddress: 0x0040);
+
+            var afterErase = ReadPage(flash, rowAddress: 0x0040, columnAddress: 0x0000, testData.Length);
+            var expectedErased = new byte[] { 0xFF, 0xFF, 0xFF, 0xFF };
+            CollectionAssert.AreEqual(expectedErased, afterErase, "Flash page should be 0xFF after block erase");
+        }
+
+        [Test]
+        public void ShouldRejectBlockEraseWithoutWriteEnable()
+        {
+            var flash = new GenericSpiNandFlash();
+            var testData = new byte[] { 0x99, 0x88, 0x77, 0x66 };
+
+            WriteEnable(flash);
+            ProgramPage(flash, rowAddress: 0x0000, columnAddress: 0x0000, testData);
+
+            // Attempt BlockErase without WriteEnable
+            BlockErase(flash, rowAddress: 0x0000);
+
+            var status = GetFeature(flash, (byte)GenericSpiNandFlash.RegisterType.Status);
+            Assert.AreEqual(0x04, status & 0x04, "E_FAIL bit (bit 2) should be set on erase without WEL");
+
+            var readBack = ReadPage(flash, rowAddress: 0x0000, columnAddress: 0x0000, testData.Length);
+            CollectionAssert.AreEqual(testData, readBack, "Block should not be erased without WEL");
+        }
+
+        [Test]
+        public void ShouldResetPeripheralOnResetCommand()
+        {
+            var flash = new GenericSpiNandFlash();
+            WriteEnable(flash);
+            var status = GetFeature(flash, (byte)GenericSpiNandFlash.RegisterType.Status);
+            Assert.AreEqual(0x02, status & 0x02);
+
+            // Send Reset command (0xFF)
+            flash.Transmit(0xFF);
+            flash.FinishTransmission();
+
+            status = GetFeature(flash, (byte)GenericSpiNandFlash.RegisterType.Status);
+            Assert.AreEqual(0, status & 0x02, "WEL bit should be reset to 0 after Reset command");
+        }
+
+        [Test]
+        public void ShouldSupportHighRowAddressForLargeCapacities()
+        {
+            // 4Gb capacity: 4096 blocks * 64 pages = 262,144 pages (0x40000 pages)
+            var flash = new GenericSpiNandFlash(blocksCount: 4096);
+            var testData = new byte[] { 0xFE, 0xED, 0xFA, 0xCE };
+
+            // Target page in block 2048 (rowAddress = 0x20000 = page 131072)
+            uint highRowAddress = 0x20000;
+            WriteEnable(flash);
+            ProgramPage(flash, rowAddress: highRowAddress, columnAddress: 0x0000, testData);
+
+            var readBack = ReadPage(flash, rowAddress: highRowAddress, columnAddress: 0x0000, testData.Length);
+            CollectionAssert.AreEqual(testData, readBack, "Page data written to high row address (RA >= 0x10000) should be read back accurately");
+        }
+
+        private byte[] ReadId(GenericSpiNandFlash flash, int count = 2)
+        {
+            flash.Transmit(0x9F);
+            flash.Transmit(0x00);
+            var result = new byte[count];
+            for(int i = 0; i < count; i++)
+            {
+                result[i] = flash.Transmit(0x00);
+            }
+            flash.FinishTransmission();
+            return result;
+        }
+
+        private byte GetFeature(GenericSpiNandFlash flash, byte regAddr)
+        {
+            flash.Transmit(0x0F);
+            flash.Transmit(regAddr);
+            var val = flash.Transmit(0x00);
+            flash.FinishTransmission();
+            return val;
+        }
+
+        private void SetFeature(GenericSpiNandFlash flash, byte regAddr, byte val)
+        {
+            flash.Transmit(0x1F);
+            flash.Transmit(regAddr);
+            flash.Transmit(val);
+            flash.FinishTransmission();
+        }
+
+        private void WriteEnable(GenericSpiNandFlash flash)
+        {
+            flash.Transmit(0x06);
+            flash.FinishTransmission();
+        }
+
+        private void WriteDisable(GenericSpiNandFlash flash)
+        {
+            flash.Transmit(0x04);
+            flash.FinishTransmission();
+        }
+
+        private void ProgramPage(GenericSpiNandFlash flash, uint rowAddress, ushort columnAddress, byte[] data, bool isRandom = false)
+        {
+            flash.Transmit((byte)(isRandom ? 0x84 : 0x02));
+            flash.Transmit((byte)(columnAddress >> 8));
+            flash.Transmit((byte)(columnAddress & 0xFF));
+            for(int i = 0; i < data.Length; i++)
+            {
+                flash.Transmit(data[i]);
+            }
+            flash.FinishTransmission();
+
+            flash.Transmit(0x10);
+            flash.Transmit((byte)(rowAddress >> 16));
+            flash.Transmit((byte)(rowAddress >> 8));
+            flash.Transmit((byte)(rowAddress & 0xFF));
+            flash.FinishTransmission();
+        }
+
+        private byte[] ReadPage(GenericSpiNandFlash flash, uint rowAddress, ushort columnAddress, int count)
+        {
+            flash.Transmit(0x13);
+            flash.Transmit((byte)(rowAddress >> 16));
+            flash.Transmit((byte)(rowAddress >> 8));
+            flash.Transmit((byte)(rowAddress & 0xFF));
+            flash.FinishTransmission();
+
+            flash.Transmit(0x03);
+            flash.Transmit((byte)(columnAddress >> 8));
+            flash.Transmit((byte)(columnAddress & 0xFF));
+            flash.Transmit(0x00);
+            var result = new byte[count];
+            for(int i = 0; i < count; i++)
+            {
+                result[i] = flash.Transmit(0x00);
+            }
+            flash.FinishTransmission();
+            return result;
+        }
+
+        private void BlockErase(GenericSpiNandFlash flash, uint rowAddress)
+        {
+            flash.Transmit(0xD8);
+            flash.Transmit((byte)(rowAddress >> 16));
+            flash.Transmit((byte)(rowAddress >> 8));
+            flash.Transmit((byte)(rowAddress & 0xFF));
+            flash.FinishTransmission();
+        }
+    }
+}


### PR DESCRIPTION
### Related issue

#789

### Description

**New Feature / Improvement**: Implements a generic, configurable `GenericSpiNandFlash` peripheral model (`ISPIPeripheral`, `IProvidesRegisterCollection<ByteRegisterCollection>`, `IGPIOReceiver`) along with comprehensive NUnit unit tests in `GenericSpiNandFlashTests`.

Key capabilities:
- **Full Standard SPI-NAND Command Set**:
  - Reset (`0xFF`)
  - Read JEDEC ID (`0x9F`) with 1 dummy byte followed by 2- or 3-byte IDs
  - Write Enable (`0x06`) / Write Disable (`0x04`) controlling `WEL` bit in Status Register
  - Get Feature (`0x0F`) / Set Feature (`0x1F`)
  - Page Read to Cache (`0x13`)
  - Read from Cache (`0x03`, `0x0B`, `0x3B`, `0x6B`) with column addressing and dummy byte
  - Program Load (`0x02`) & Program Load Random (`0x84`)
  - Program Execute (`0x10`) with `WEL` gating and `P_FAIL` status reporting
  - Block Erase (`0xD8`) with `WEL` gating and `E_FAIL` status reporting
- **Configurable Geometry**:
  - `pageSize` (default 2048), `spareSize` (default 64), `pagesPerBlock` (default 64), `blocksCount` (default 1024), `manufacturerId` (default 0x52), `deviceId` (default 0x24).
- **2Gb / 4Gb+ Row Addressing Support**:
  - Supports 24-bit row address decoding (`RA16..RA19` carried in lower nibble of the first address byte) for 2Gb/4Gb chips like Alliance Memory AS5F14G04SND and Winbond W25N02GV/W25N04GV.
- **Feature Registers**:
  - Block Lock (`0xA0`), Configuration (`0xB0`), Status (`0xC0`), and Die Select (`0xD0`).

### Usage example

Can be instantiated directly in C# or via platform `.repl` files:

```csharp
var flash = new GenericSpiNandFlash(manufacturerId: 0x52, deviceId: 0x24, blocksCount: 1024);
flash.Transmit(0x06); // Write Enable
flash.FinishTransmission();
```

### Additional information

All 11 unit tests in `GenericSpiNandFlashTests` pass cleanly.
