### PR TITLE
[#970] MCXN947: Add supporting peripheral models

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/MCXN94_GPIO.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/MCXN94_GPIO.cs
@@ -1,0 +1,578 @@
+//
+// Copyright (c) 2010-2026 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+using Antmicro.Renode.Utilities;
+
+namespace Antmicro.Renode.Peripherals.GPIOPort
+{
+    public class MCXN94_GPIO : BaseGPIOPort, IBusPeripheral, IKnownSize
+    {
+        public MCXN94_GPIO(IMachine machine) : base(machine, NumberOfPins)
+        {
+            IRQ0 = new GPIO();
+            IRQ1 = new GPIO();
+
+            interruptEnabled = new bool[NumberOfPins];
+            interruptRoute = new bool[NumberOfPins];
+            interruptType = new GPIOInterruptManager.InterruptTrigger[NumberOfPins];
+            pinDirection = Enumerable.Repeat(GPIOInterruptManager.Direction.Input, NumberOfPins).ToArray();
+            outputData = new bool[NumberOfPins];
+            previousState = new bool[NumberOfPins];
+            activeInterrupts = new bool[NumberOfPins];
+
+            DefineGPIORegisters();
+            DefinePORTRegisters();
+        }
+
+        [ConnectionRegion("gpio")]
+        public uint ReadDoubleWordFromGPIO(long offset)
+        {
+            lock(locker)
+            {
+                return gpioRegisters.Read(offset);
+            }
+        }
+
+        [ConnectionRegion("gpio")]
+        public void WriteDoubleWordToGPIO(long offset, uint value)
+        {
+            lock(locker)
+            {
+                gpioRegisters.Write(offset, value);
+            }
+        }
+
+        [ConnectionRegion("gpio")]
+        public byte ReadByteFromGPIO(long offset)
+        {
+            lock(locker)
+            {
+                if(TryReadPinDataByte(offset, out var result))
+                {
+                    return result;
+                }
+
+                this.LogUnhandledRead(offset);
+                return 0;
+            }
+        }
+
+        [ConnectionRegion("gpio")]
+        public void WriteByteToGPIO(long offset, byte value)
+        {
+            lock(locker)
+            {
+                if(TryWritePinDataByte(offset, value))
+                {
+                    return;
+                }
+
+                this.LogUnhandledWrite(offset, value);
+            }
+        }
+
+        [ConnectionRegion("port")]
+        public uint ReadDoubleWordFromPORT(long offset)
+        {
+            lock(locker)
+            {
+                return portRegisters.Read(offset);
+            }
+        }
+
+        [ConnectionRegion("port")]
+        public void WriteDoubleWordToPORT(long offset, uint value)
+        {
+            lock(locker)
+            {
+                portRegisters.Write(offset, value);
+            }
+        }
+
+        public override void OnGPIO(int number, bool value)
+        {
+            lock(locker)
+            {
+                if(!CheckPinNumber(number))
+                {
+                    return;
+                }
+
+                if(inputDisabled[number].Value)
+                {
+                    return;
+                }
+
+                base.OnGPIO(number, value);
+                RefreshInterrupts();
+            }
+        }
+
+        public override void Reset()
+        {
+            lock(locker)
+            {
+                base.Reset();
+                gpioRegisters.Reset();
+                portRegisters.Reset();
+
+                Array.Clear(interruptEnabled, 0, interruptEnabled.Length);
+                Array.Clear(interruptRoute, 0, interruptRoute.Length);
+                Array.Clear(interruptType, 0, interruptType.Length);
+                Array.Clear(outputData, 0, outputData.Length);
+                Array.Clear(previousState, 0, previousState.Length);
+                Array.Clear(activeInterrupts, 0, activeInterrupts.Length);
+                for(var i = 0; i < pinDirection.Length; ++i)
+                {
+                    pinDirection[i] = GPIOInterruptManager.Direction.Input;
+                }
+
+                IRQ0.Unset();
+                IRQ1.Unset();
+            }
+        }
+
+        public GPIO IRQ0 { get; }
+
+        public GPIO IRQ1 { get; }
+
+        public long Size => 0x200;
+
+        private static bool IsInterruptConfiguration(InterruptConfiguration configuration)
+        {
+            return configuration == InterruptConfiguration.InterruptWhenLow
+                || configuration == InterruptConfiguration.InterruptRisingEdge
+                || configuration == InterruptConfiguration.InterruptFallingEdge
+                || configuration == InterruptConfiguration.InterruptEitherEdge
+                || configuration == InterruptConfiguration.InterruptWhenHigh;
+        }
+
+        private void DefineGPIORegisters()
+        {
+            var registers = new Dictionary<long, DoubleWordRegister>
+            {
+                {(long)GPIORegisters.PortDataOutput, new DoubleWordRegister(this)
+                    .WithValueField(0, NumberOfPins,
+                        valueProviderCallback: _ => BitHelper.GetValueFromBitsArray(outputData),
+                        writeCallback: (_, value) =>
+                        {
+                            for(var i = 0; i < NumberOfPins; ++i)
+                            {
+                                outputData[i] = BitHelper.IsBitSet(value, (byte)i);
+                            }
+                        },
+                        name: "PDOR")
+                    .WithWriteCallback((_, __) => UpdateConnections())
+                },
+                {(long)GPIORegisters.PortSetOutput, new DoubleWordRegister(this)
+                    .WithValueField(0, NumberOfPins, FieldMode.Write,
+                        writeCallback: (_, value) =>
+                        {
+                            for(var i = 0; i < NumberOfPins; ++i)
+                            {
+                                if(BitHelper.IsBitSet(value, (byte)i))
+                                {
+                                    outputData[i] = true;
+                                }
+                            }
+                        },
+                        name: "PSOR")
+                    .WithWriteCallback((_, __) => UpdateConnections())
+                },
+                {(long)GPIORegisters.PortClearOutput, new DoubleWordRegister(this)
+                    .WithValueField(0, NumberOfPins, FieldMode.Write,
+                        writeCallback: (_, value) =>
+                        {
+                            for(var i = 0; i < NumberOfPins; ++i)
+                            {
+                                if(BitHelper.IsBitSet(value, (byte)i))
+                                {
+                                    outputData[i] = false;
+                                }
+                            }
+                        },
+                        name: "PCOR")
+                    .WithWriteCallback((_, __) => UpdateConnections())
+                },
+                {(long)GPIORegisters.PortToggleOutput, new DoubleWordRegister(this)
+                    .WithValueField(0, NumberOfPins, FieldMode.Write,
+                        writeCallback: (_, value) =>
+                        {
+                            for(var i = 0; i < NumberOfPins; ++i)
+                            {
+                                if(BitHelper.IsBitSet(value, (byte)i))
+                                {
+                                    outputData[i] ^= true;
+                                }
+                            }
+                        },
+                        name: "PTOR")
+                    .WithWriteCallback((_, __) => UpdateConnections())
+                },
+                {(long)GPIORegisters.PortDataInput, new DoubleWordRegister(this)
+                    .WithValueField(0, NumberOfPins, FieldMode.Read, valueProviderCallback: _ => GetInputBits(), name: "PDIR")
+                },
+                {(long)GPIORegisters.PortDataDirection, new DoubleWordRegister(this)
+                    .WithFlags(0, NumberOfPins,
+                        writeCallback: (index, _, value) => pinDirection[index] = value ? GPIOInterruptManager.Direction.Output : GPIOInterruptManager.Direction.Input,
+                        valueProviderCallback: (index, _) => IsOutput(index),
+                        name: "PDDR")
+                    .WithWriteCallback((_, __) =>
+                    {
+                        UpdateConnections();
+                        RefreshInterrupts();
+                    })
+                },
+                {(long)GPIORegisters.PortInputDisable, new DoubleWordRegister(this)
+                    .WithFlags(0, NumberOfPins, out inputDisabled, name: "PIDR")
+                    .WithWriteCallback((_, __) => RefreshInterrupts())
+                },
+                {(long)GPIORegisters.GlobalInterruptControlLow, new DoubleWordRegister(this)
+                    .WithValueField(0, 16, out var interruptWriteEnableLow, FieldMode.Write, name: "GIWE")
+                    .WithValueField(16, 16, FieldMode.Write,
+                        writeCallback: (_, value) => GlobalInterruptControlWrite((ushort)value, (ushort)interruptWriteEnableLow.Value, upperPins: false),
+                        name: "GIWD")
+                },
+                {(long)GPIORegisters.GlobalInterruptControlHigh, new DoubleWordRegister(this)
+                    .WithValueField(0, 16, out var interruptWriteEnableHigh, FieldMode.Write, name: "GIWE")
+                    .WithValueField(16, 16, FieldMode.Write,
+                        writeCallback: (_, value) => GlobalInterruptControlWrite((ushort)value, (ushort)interruptWriteEnableHigh.Value, upperPins: true),
+                        name: "GIWD")
+                },
+                {(long)GPIORegisters.InterruptStatusFlags0, new DoubleWordRegister(this)
+                    .WithFlags(0, NumberOfPins, FieldMode.Read | FieldMode.WriteOneToClear,
+                        valueProviderCallback: (index, _) => !interruptRoute[index] && activeInterrupts[index],
+                        writeCallback: (index, _, value) =>
+                        {
+                            if(value && !interruptRoute[index])
+                            {
+                                activeInterrupts[index] = false;
+                            }
+                        },
+                        name: "ISF")
+                    .WithWriteCallback((_, __) => RefreshInterrupts())
+                },
+                {(long)GPIORegisters.InterruptStatusFlags1, new DoubleWordRegister(this)
+                    .WithFlags(0, NumberOfPins, FieldMode.Read | FieldMode.WriteOneToClear,
+                        valueProviderCallback: (index, _) => interruptRoute[index] && activeInterrupts[index],
+                        writeCallback: (index, _, value) =>
+                        {
+                            if(value && interruptRoute[index])
+                            {
+                                activeInterrupts[index] = false;
+                            }
+                        },
+                        name: "ISF")
+                    .WithWriteCallback((_, __) => RefreshInterrupts())
+                },
+            };
+
+            interruptControlRegisters = new DoubleWordRegister[NumberOfPins];
+            for(var i = 0; i < NumberOfPins; ++i)
+            {
+                var index = i;
+                interruptControlRegisters[index] = new DoubleWordRegister(this)
+                    .WithReservedBits(0, 16)
+                    .WithEnumField<DoubleWordRegister, InterruptConfiguration>(16, 4,
+                        writeCallback: (_, value) =>
+                        {
+                            interruptEnabled[index] = IsInterruptConfiguration(value);
+                            interruptType[index] = CalculateInterruptType(value);
+                            RefreshInterrupts();
+                        },
+                        name: "IRQC")
+                    .WithFlag(20, writeCallback: (_, value) =>
+                        {
+                            interruptRoute[index] = value;
+                            RefreshInterrupts();
+                        },
+                        valueProviderCallback: _ => interruptRoute[index],
+                        name: "IRQS")
+                    .WithReservedBits(21, 3)
+                    .WithFlag(24, FieldMode.Read | FieldMode.WriteOneToClear,
+                        valueProviderCallback: _ => activeInterrupts[index],
+                        writeCallback: (_, value) =>
+                        {
+                            if(value)
+                            {
+                                activeInterrupts[index] = false;
+                                RefreshInterrupts();
+                            }
+                        },
+                        name: "ISF")
+                    .WithReservedBits(25, 7);
+                registers.Add((long)GPIORegisters.InterruptControlBase + (0x4 * index), interruptControlRegisters[index]);
+            }
+
+            gpioRegisters = new DoubleWordRegisterCollection(this, registers);
+        }
+
+        private void DefinePORTRegisters()
+        {
+            var registers = new Dictionary<long, DoubleWordRegister>
+            {
+                {(long)PORTRegisters.GlobalPinControlLow, new DoubleWordRegister(this)
+                    .WithValueField(0, 16, out var pinWriteEnableLow, FieldMode.Write, name: "GPWE")
+                    .WithValueField(16, 16, FieldMode.Write,
+                        writeCallback: (_, value) => GlobalPinControlWrite((ushort)value, (ushort)pinWriteEnableLow.Value, upperPins: false),
+                        name: "GPWD")
+                },
+                {(long)PORTRegisters.GlobalPinControlHigh, new DoubleWordRegister(this)
+                    .WithValueField(0, 16, out var pinWriteEnableHigh, FieldMode.Write, name: "GPWE")
+                    .WithValueField(16, 16, FieldMode.Write,
+                        writeCallback: (_, value) => GlobalPinControlWrite((ushort)value, (ushort)pinWriteEnableHigh.Value, upperPins: true),
+                        name: "GPWD")
+                },
+            };
+
+            portControlRegisters = new DoubleWordRegister[NumberOfPins];
+            for(var i = 0; i < NumberOfPins; ++i)
+            {
+                portControlRegisters[i] = new DoubleWordRegister(this)
+                    .WithValueField(0, 32, name: "PCR");
+                registers.Add((long)PORTRegisters.PortControlBase + (0x4 * i), portControlRegisters[i]);
+            }
+
+            portRegisters = new DoubleWordRegisterCollection(this, registers);
+        }
+
+        private void GlobalPinControlWrite(ushort value, ushort whichPins, bool upperPins)
+        {
+            var firstPin = upperPins ? 16 : 0;
+            for(var i = firstPin; i < firstPin + 16; ++i)
+            {
+                if(!BitHelper.IsBitSet(whichPins, (byte)(i - firstPin)))
+                {
+                    continue;
+                }
+
+                var currentValue = portControlRegisters[i].Read();
+                BitHelper.SetMaskedValue(ref currentValue, value, 0, 16);
+                portControlRegisters[i].Write((long)PORTRegisters.PortControlBase + 0x4 * i, currentValue);
+            }
+        }
+
+        private void GlobalInterruptControlWrite(ushort value, ushort whichPins, bool upperPins)
+        {
+            var firstPin = upperPins ? 16 : 0;
+            for(var i = firstPin; i < firstPin + 16; ++i)
+            {
+                if(!BitHelper.IsBitSet(whichPins, (byte)(i - firstPin)))
+                {
+                    continue;
+                }
+
+                var currentValue = interruptControlRegisters[i].Read();
+                BitHelper.SetMaskedValue(ref currentValue, value, 16, 16);
+                interruptControlRegisters[i].Write((long)GPIORegisters.InterruptControlBase + 0x4 * i, currentValue);
+            }
+        }
+
+        private void RefreshInterrupts()
+        {
+            var irq0State = false;
+            var irq1State = false;
+
+            for(var i = 0; i < NumberOfPins; ++i)
+            {
+                if(interruptEnabled[i] && !inputDisabled[i].Value && !IsOutput(i))
+                {
+                    var currentState = State[i];
+                    var edge = currentState != previousState[i];
+
+                    switch(interruptType[i])
+                    {
+                    case GPIOInterruptManager.InterruptTrigger.ActiveHigh:
+                        activeInterrupts[i] |= currentState;
+                        break;
+                    case GPIOInterruptManager.InterruptTrigger.ActiveLow:
+                        activeInterrupts[i] |= !currentState;
+                        break;
+                    case GPIOInterruptManager.InterruptTrigger.RisingEdge:
+                        activeInterrupts[i] |= edge && currentState;
+                        break;
+                    case GPIOInterruptManager.InterruptTrigger.FallingEdge:
+                        activeInterrupts[i] |= edge && !currentState;
+                        break;
+                    case GPIOInterruptManager.InterruptTrigger.BothEdges:
+                        activeInterrupts[i] |= edge;
+                        break;
+                    default:
+                        break;
+                    }
+                }
+
+                previousState[i] = State[i];
+
+                if(!activeInterrupts[i])
+                {
+                    continue;
+                }
+
+                if(interruptRoute[i])
+                {
+                    irq1State = true;
+                }
+                else
+                {
+                    irq0State = true;
+                }
+            }
+
+            IRQ0.Set(irq0State);
+            IRQ1.Set(irq1State);
+        }
+
+        private GPIOInterruptManager.InterruptTrigger CalculateInterruptType(InterruptConfiguration type)
+        {
+            switch(type)
+            {
+            case InterruptConfiguration.InterruptWhenLow:
+                return GPIOInterruptManager.InterruptTrigger.ActiveLow;
+            case InterruptConfiguration.InterruptFallingEdge:
+                return GPIOInterruptManager.InterruptTrigger.FallingEdge;
+            case InterruptConfiguration.InterruptRisingEdge:
+                return GPIOInterruptManager.InterruptTrigger.RisingEdge;
+            case InterruptConfiguration.InterruptEitherEdge:
+                return GPIOInterruptManager.InterruptTrigger.BothEdges;
+            case InterruptConfiguration.InterruptWhenHigh:
+                return GPIOInterruptManager.InterruptTrigger.ActiveHigh;
+            case InterruptConfiguration.Disabled:
+            case InterruptConfiguration.DMARequestRisingEdge:
+            case InterruptConfiguration.DMARequestFallingEdge:
+            case InterruptConfiguration.DMARequestEitherEdge:
+                return GPIOInterruptManager.InterruptTrigger.ActiveLow;
+            default:
+                this.Log(LogLevel.Warning, "Unsupported interrupt configuration: {0}", type);
+                return GPIOInterruptManager.InterruptTrigger.ActiveLow;
+            }
+        }
+
+        private bool TryReadPinDataByte(long offset, out byte value)
+        {
+            value = 0;
+            if(offset < (long)GPIORegisters.PinDataBase || offset >= (long)GPIORegisters.PinDataBase + NumberOfPins)
+            {
+                return false;
+            }
+
+            var pin = (int)(offset - (long)GPIORegisters.PinDataBase);
+            value = (byte)(GetPinData(pin) ? 1 : 0);
+            return true;
+        }
+
+        private bool TryWritePinDataByte(long offset, byte value)
+        {
+            if(offset < (long)GPIORegisters.PinDataBase || offset >= (long)GPIORegisters.PinDataBase + NumberOfPins)
+            {
+                return false;
+            }
+
+            var pin = (int)(offset - (long)GPIORegisters.PinDataBase);
+            outputData[pin] = (value & 0x1) != 0;
+            UpdateConnections();
+            return true;
+        }
+
+        private bool GetPinData(int pin)
+        {
+            if(IsOutput(pin))
+            {
+                return outputData[pin];
+            }
+
+            return !inputDisabled[pin].Value && State[pin];
+        }
+
+        private uint GetInputBits()
+        {
+            var value = 0u;
+            for(var i = 0; i < NumberOfPins; ++i)
+            {
+                if(!IsOutput(i) && !inputDisabled[i].Value && State[i])
+                {
+                    value |= 1u << i;
+                }
+            }
+            return value;
+        }
+
+        private bool IsOutput(int pin)
+        {
+            return (pinDirection[pin] & GPIOInterruptManager.Direction.Output) != 0;
+        }
+
+        private void UpdateConnections()
+        {
+            for(var i = 0; i < NumberOfPins; ++i)
+            {
+                Connections[i].Set(IsOutput(i) && outputData[i]);
+            }
+        }
+
+        private DoubleWordRegisterCollection gpioRegisters;
+        private DoubleWordRegisterCollection portRegisters;
+        private DoubleWordRegister[] interruptControlRegisters;
+        private DoubleWordRegister[] portControlRegisters;
+        private IFlagRegisterField[] inputDisabled;
+
+        private readonly bool[] interruptEnabled;
+        private readonly bool[] interruptRoute;
+        private readonly GPIOInterruptManager.InterruptTrigger[] interruptType;
+        private readonly GPIOInterruptManager.Direction[] pinDirection;
+        private readonly bool[] outputData;
+        private readonly bool[] previousState;
+        private readonly bool[] activeInterrupts;
+        private readonly object locker = new object();
+
+        private const int NumberOfPins = 32;
+
+        private enum InterruptConfiguration
+        {
+            Disabled = 0,
+            DMARequestRisingEdge = 1,
+            DMARequestFallingEdge = 2,
+            DMARequestEitherEdge = 3,
+            InterruptWhenLow = 8,
+            InterruptRisingEdge = 9,
+            InterruptFallingEdge = 10,
+            InterruptEitherEdge = 11,
+            InterruptWhenHigh = 12,
+        }
+
+        private enum GPIORegisters : long
+        {
+            PortDataOutput = 0x40,
+            PortSetOutput = 0x44,
+            PortClearOutput = 0x48,
+            PortToggleOutput = 0x4C,
+            PortDataInput = 0x50,
+            PortDataDirection = 0x54,
+            PortInputDisable = 0x58,
+            PinDataBase = 0x60,
+            InterruptControlBase = 0x80,
+            GlobalInterruptControlLow = 0x100,
+            GlobalInterruptControlHigh = 0x104,
+            InterruptStatusFlags0 = 0x120,
+            InterruptStatusFlags1 = 0x124,
+        }
+
+        private enum PORTRegisters : long
+        {
+            GlobalPinControlLow = 0x10,
+            GlobalPinControlHigh = 0x14,
+            PortControlBase = 0x80,
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/SPI/IMXRT_LPSPI.cs
+++ b/src/Emulator/Peripherals/Peripherals/SPI/IMXRT_LPSPI.cs
@@ -86,7 +86,8 @@ namespace Antmicro.Renode.Peripherals.SPI
                 .WithFlag(13, out dataMatch, FieldMode.Read | FieldMode.WriteOneToClear, name: "DMF - Data Match Flag")
                 .WithReservedBits(14, 10)
                 .WithTaggedFlag("MBF - Module Busy Flag", 24)
-                .WithReservedBits(25, 7);
+                .WithReservedBits(25, 7)
+                .WithWriteCallback((_, __) => UpdateInterrupts());
 
             Registers.TransmitCommand.Define(this)
                 .WithValueField(0, 12, out frameSize, name: "FRAMESZ - Frame Size")
@@ -428,7 +429,7 @@ namespace Antmicro.Renode.Peripherals.SPI
 
             flag |= receiveDataInterruptEnable.Value && receiveFifo.Count > (int)rxWatermark.Value;
             flag |= transferComplete.Value && transferCompleteInterruptEnable.Value;
-            flag |= dataMatch.Value | dataMatchInterruptEnable.Value;
+            flag |= dataMatch.Value && dataMatchInterruptEnable.Value;
 
             this.Log(LogLevel.Debug, "Setting IRQ flag to {0}", flag);
             IRQ.Set(flag);

--- a/src/Emulator/Peripherals/Peripherals/Timers/MCXN94_CDOG.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/MCXN94_CDOG.cs
@@ -1,0 +1,470 @@
+//
+// Copyright (c) 2010-2026 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+
+using System;
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Time;
+
+namespace Antmicro.Renode.Peripherals.Timers
+{
+    public class MCXN94_CDOG : BasicDoubleWordPeripheral, IKnownSize
+    {
+        public MCXN94_CDOG(IMachine machine, ulong frequency = DefaultFrequency) : base(machine)
+        {
+            IRQ = new GPIO();
+
+            instructionTimer = new LimitTimer(machine.ClockSource, frequency, this, "CDOGInstructionTimer", uint.MaxValue, workMode: WorkMode.OneShot, enabled: false, eventEnabled: true, autoUpdate: true);
+            instructionTimer.LimitReached += () => RaiseFault(FaultFlags.Timeout, "CDOG instruction timer expired");
+
+            DefineRegisters();
+            Reset();
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+
+            instructionTimer.Reset();
+
+            lockControl = LockControl.Unlocked;
+            timeoutAction = FaultAction.Interrupt;
+            miscompareAction = FaultAction.Interrupt;
+            sequenceAction = FaultAction.Interrupt;
+            stateAction = FaultAction.Disabled;
+            addressAction = FaultAction.Disabled;
+            irqPauseControl = PauseControl.KeepRunning;
+            debugHaltControl = PauseControl.KeepRunning;
+
+            reloadValue = DefaultReloadValue;
+            secureCounter = 0;
+            running = false;
+            timeoutFaultCount = 0;
+            miscompareFaultCount = 0;
+            sequenceFaultCount = 0;
+
+            // Fault flags and persistent data survive a software reset on MCXN94.
+            // Renode does not expose a separate power-on reset path for this peripheral.
+            IRQ.Unset();
+        }
+
+        public void InjectMiscompareFault()
+        {
+            RaiseFault(FaultFlags.Miscompare, "CDOG miscompare fault injected");
+        }
+
+        public void InjectSequenceFault()
+        {
+            RaiseFault(FaultFlags.Sequence, "CDOG sequence fault injected");
+        }
+
+        public void InjectIllegalSequenceFault()
+        {
+            InjectSequenceFault();
+        }
+
+        public void InjectTimeoutFault()
+        {
+            RaiseFault(FaultFlags.Timeout, "CDOG timeout fault injected");
+        }
+
+        public GPIO IRQ { get; }
+
+        public long Size => 0x1000;
+
+        private void DefineRegisters()
+        {
+            Registers.Control.Define(this)
+                .WithValueField(0, 32, name: "CONTROL",
+                    valueProviderCallback: _ => ComposeControl(),
+                    writeCallback: (_, value) => ApplyControl((uint)value));
+
+            Registers.Reload.Define(this, DefaultReloadValue)
+                .WithValueField(0, 32, name: "RELOAD",
+                    valueProviderCallback: _ => reloadValue,
+                    writeCallback: (_, value) =>
+                    {
+                        reloadValue = (uint)value;
+                        if(running)
+                        {
+                            ReloadInstructionTimer();
+                        }
+                    });
+
+            Registers.InstructionTimer.Define(this)
+                .WithValueField(0, 32, FieldMode.Read, name: "INSTRUCTION_TIMER",
+                    valueProviderCallback: _ => running ? (uint)instructionTimer.Value : reloadValue);
+
+            Registers.Status.Define(this)
+                .WithValueField(0, 32, FieldMode.Read, name: "STATUS",
+                    valueProviderCallback: _ => ComposeStatus());
+
+            Registers.Status2.Define(this)
+                .WithValueField(0, 32, FieldMode.Read, name: "STATUS2",
+                    valueProviderCallback: _ => secureCounter);
+
+            Registers.Flags.Define(this)
+                .WithValueField(0, 32, name: "FLAGS",
+                    valueProviderCallback: _ => (uint)flags,
+                    writeCallback: (_, value) =>
+                    {
+                        flags &= ~(FaultFlags)(uint)value;
+                        UpdateInterrupts();
+                    });
+
+            Registers.Persistent.Define(this)
+                .WithValueField(0, 32, name: "PERSISTENT",
+                    valueProviderCallback: _ => persistentValue,
+                    writeCallback: (_, value) => persistentValue = (uint)value);
+
+            Registers.Start.Define(this)
+                .WithValueField(0, 32, FieldMode.Write, name: "START",
+                    writeCallback: (_, value) => Start((uint)value));
+
+            Registers.Stop.Define(this)
+                .WithValueField(0, 32, FieldMode.Write, name: "STOP",
+                    writeCallback: (_, value) => Stop((uint)value));
+
+            Registers.Restart.Define(this)
+                .WithValueField(0, 32, FieldMode.Write, name: "RESTART",
+                    writeCallback: (_, value) => Restart((uint)value));
+
+            Registers.Add.Define(this)
+                .WithValueField(0, 32, FieldMode.Write, name: "ADD",
+                    writeCallback: (_, value) => Add((uint)value));
+
+            Registers.Add1.Define(this)
+                .WithValueField(0, 32, FieldMode.Write, name: "ADD1",
+                    writeCallback: (_, __) => Add(1));
+
+            Registers.Add16.Define(this)
+                .WithValueField(0, 32, FieldMode.Write, name: "ADD16",
+                    writeCallback: (_, __) => Add(16));
+
+            Registers.Add256.Define(this)
+                .WithValueField(0, 32, FieldMode.Write, name: "ADD256",
+                    writeCallback: (_, __) => Add(256));
+
+            Registers.Sub.Define(this)
+                .WithValueField(0, 32, FieldMode.Write, name: "SUB",
+                    writeCallback: (_, value) => Sub((uint)value));
+
+            Registers.Sub1.Define(this)
+                .WithValueField(0, 32, FieldMode.Write, name: "SUB1",
+                    writeCallback: (_, __) => Sub(1));
+
+            Registers.Sub16.Define(this)
+                .WithValueField(0, 32, FieldMode.Write, name: "SUB16",
+                    writeCallback: (_, __) => Sub(16));
+
+            Registers.Sub256.Define(this)
+                .WithValueField(0, 32, FieldMode.Write, name: "SUB256",
+                    writeCallback: (_, __) => Sub(256));
+
+            Registers.Assert16.Define(this)
+                .WithValueField(0, 16, FieldMode.Write, name: "ASSERT16",
+                    writeCallback: (_, value) => Assert16((ushort)value))
+                .WithReservedBits(16, 16);
+        }
+
+        private void Start(uint value)
+        {
+            if(running)
+            {
+                RaiseFault(FaultFlags.Sequence, "CDOG START issued while already running");
+                return;
+            }
+
+            secureCounter = value;
+            running = true;
+            ReloadInstructionTimer();
+            UpdateInterrupts();
+        }
+
+        private void Stop(uint expectedValue)
+        {
+            if(!EnsureRunning(Command.Stop))
+            {
+                return;
+            }
+
+            if(secureCounter != expectedValue)
+            {
+                RaiseFault(FaultFlags.Miscompare, $"CDOG STOP expected 0x{expectedValue:X8}, got 0x{secureCounter:X8}");
+                return;
+            }
+
+            running = false;
+            instructionTimer.Enabled = false;
+            UpdateInterrupts();
+        }
+
+        private void Restart(uint value)
+        {
+            if(!EnsureRunning(Command.Restart))
+            {
+                return;
+            }
+
+            if(value != 0)
+            {
+                secureCounter = value;
+            }
+
+            ReloadInstructionTimer();
+        }
+
+        private void Add(uint value)
+        {
+            if(!EnsureRunning(Command.Add))
+            {
+                return;
+            }
+
+            secureCounter += value;
+            ReloadInstructionTimer();
+        }
+
+        private void Sub(uint value)
+        {
+            if(!EnsureRunning(Command.Sub))
+            {
+                return;
+            }
+
+            secureCounter -= value;
+            ReloadInstructionTimer();
+        }
+
+        private void Assert16(ushort expectedValue)
+        {
+            if(!EnsureRunning(Command.Assert16))
+            {
+                return;
+            }
+
+            if((secureCounter & 0xFFFFu) != expectedValue)
+            {
+                RaiseFault(FaultFlags.Miscompare, $"CDOG ASSERT16 expected 0x{expectedValue:X4}, got 0x{secureCounter & 0xFFFFu:X4}");
+                return;
+            }
+
+            ReloadInstructionTimer();
+        }
+
+        private bool EnsureRunning(Command command)
+        {
+            if(!running)
+            {
+                RaiseFault(FaultFlags.Sequence, $"CDOG {command} issued while idle");
+                return false;
+            }
+
+            return true;
+        }
+
+        private void ReloadInstructionTimer()
+        {
+            var value = Math.Max(1u, reloadValue);
+            instructionTimer.Limit = value;
+            instructionTimer.Value = value;
+            instructionTimer.Enabled = running;
+            instructionTimer.EventEnabled = running;
+        }
+
+        private uint ComposeControl()
+        {
+            var value = 0u;
+            value |= (uint)lockControl;
+            value |= ((uint)timeoutAction & 0x7u) << 2;
+            value |= ((uint)miscompareAction & 0x7u) << 5;
+            value |= ((uint)sequenceAction & 0x7u) << 8;
+            value |= ((uint)stateAction & 0x7u) << 14;
+            value |= ((uint)addressAction & 0x7u) << 17;
+            value |= ((uint)irqPauseControl & 0x3u) << 28;
+            value |= ((uint)debugHaltControl & 0x3u) << 30;
+            return value;
+        }
+
+        private void ApplyControl(uint value)
+        {
+            if(lockControl == LockControl.Locked)
+            {
+                this.Log(LogLevel.Warning, "Ignoring write to locked CDOG CONTROL register");
+                return;
+            }
+
+            lockControl = (LockControl)(value & 0x3u);
+            timeoutAction = (FaultAction)((value >> 2) & 0x7u);
+            miscompareAction = (FaultAction)((value >> 5) & 0x7u);
+            sequenceAction = (FaultAction)((value >> 8) & 0x7u);
+            stateAction = (FaultAction)((value >> 14) & 0x7u);
+            addressAction = (FaultAction)((value >> 17) & 0x7u);
+            irqPauseControl = (PauseControl)((value >> 28) & 0x3u);
+            debugHaltControl = (PauseControl)((value >> 30) & 0x3u);
+            UpdateInterrupts();
+        }
+
+        private uint ComposeStatus()
+        {
+            var value = 0u;
+            value |= timeoutFaultCount;
+            value |= (uint)miscompareFaultCount << 8;
+            value |= (uint)sequenceFaultCount << 16;
+            value |= (running ? 1u : 0u) << 28;
+            return value;
+        }
+
+        private void RaiseFault(FaultFlags flag, string reason)
+        {
+            flags |= flag;
+            if((flag & FaultFlags.Timeout) != 0)
+            {
+                timeoutFaultCount++;
+            }
+            if((flag & FaultFlags.Miscompare) != 0)
+            {
+                miscompareFaultCount++;
+            }
+            if((flag & FaultFlags.Sequence) != 0)
+            {
+                sequenceFaultCount++;
+            }
+            running = false;
+            instructionTimer.Enabled = false;
+            this.Log(LogLevel.Warning, reason);
+
+            switch(GetFaultAction(flag))
+            {
+            case FaultAction.Reset:
+                UpdateInterrupts();
+                machine.RequestReset();
+                break;
+            case FaultAction.Interrupt:
+            case FaultAction.Disabled:
+                UpdateInterrupts();
+                break;
+            default:
+                this.Log(LogLevel.Warning, "Unsupported CDOG fault action, treating as disabled");
+                UpdateInterrupts();
+                break;
+            }
+        }
+
+        private void UpdateInterrupts()
+        {
+            var interrupt = ((flags & FaultFlags.Timeout) != 0 && timeoutAction == FaultAction.Interrupt)
+                || ((flags & FaultFlags.Miscompare) != 0 && miscompareAction == FaultAction.Interrupt)
+                || ((flags & FaultFlags.Sequence) != 0 && sequenceAction == FaultAction.Interrupt);
+            IRQ.Set(interrupt);
+        }
+
+        private FaultAction GetFaultAction(FaultFlags flag)
+        {
+            if((flag & FaultFlags.Timeout) != 0)
+            {
+                return timeoutAction;
+            }
+            if((flag & FaultFlags.Miscompare) != 0)
+            {
+                return miscompareAction;
+            }
+            if((flag & FaultFlags.Sequence) != 0)
+            {
+                return sequenceAction;
+            }
+            return FaultAction.Disabled;
+        }
+
+        private bool running;
+
+        private uint reloadValue;
+        private uint secureCounter;
+        private uint persistentValue;
+
+        private LockControl lockControl;
+        private FaultAction timeoutAction;
+        private FaultAction miscompareAction;
+        private FaultAction sequenceAction;
+        private FaultAction stateAction;
+        private FaultAction addressAction;
+        private PauseControl irqPauseControl;
+        private PauseControl debugHaltControl;
+        private FaultFlags flags;
+        private byte timeoutFaultCount;
+        private byte miscompareFaultCount;
+        private byte sequenceFaultCount;
+
+        private readonly LimitTimer instructionTimer;
+
+        private const uint DefaultReloadValue = 0xFFFF;
+        private const ulong DefaultFrequency = 1;
+
+        [Flags]
+        private enum FaultFlags : uint
+        {
+            None = 0,
+            Timeout = 1u << 0,
+            Miscompare = 1u << 1,
+            Sequence = 1u << 2,
+        }
+
+        private enum FaultAction : uint
+        {
+            Reset = 0b001,
+            Interrupt = 0b010,
+            Disabled = 0b100,
+        }
+
+        private enum LockControl : uint
+        {
+            Locked = 0b01,
+            Unlocked = 0b10,
+        }
+
+        private enum PauseControl : uint
+        {
+            KeepRunning = 0b01,
+            Pause = 0b10,
+        }
+
+        private enum Command : uint
+        {
+            Start = 1,
+            Stop = 2,
+            Restart = 3,
+            Add = 4,
+            Sub = 5,
+            Assert16 = 6,
+        }
+
+        private enum Registers : long
+        {
+            Control = 0x0,
+            Reload = 0x4,
+            InstructionTimer = 0x8,
+            Status = 0x10,
+            Status2 = 0x14,
+            Flags = 0x18,
+            Persistent = 0x1C,
+            Start = 0x20,
+            Stop = 0x24,
+            Restart = 0x28,
+            Add = 0x2C,
+            Add1 = 0x30,
+            Add16 = 0x34,
+            Add256 = 0x38,
+            Sub = 0x3C,
+            Sub1 = 0x40,
+            Sub16 = 0x44,
+            Sub256 = 0x48,
+            Assert16 = 0x4C,
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/Timers/MCXN94_WWDT.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/MCXN94_WWDT.cs
@@ -1,0 +1,301 @@
+//
+// Copyright (c) 2010-2026 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+
+using System;
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Time;
+
+namespace Antmicro.Renode.Peripherals.Timers
+{
+    public class MCXN94_WWDT : BasicDoubleWordPeripheral, IKnownSize
+    {
+        public MCXN94_WWDT(IMachine machine, ulong frequency = DefaultFrequency) : base(machine)
+        {
+            IRQ = new GPIO();
+
+            timeoutTimer = new LimitTimer(machine.ClockSource, frequency, this, "WWDTTimeout", 0xFFFFFF, workMode: WorkMode.OneShot, enabled: false, eventEnabled: true, autoUpdate: true);
+            timeoutTimer.LimitReached += HandleTimeout;
+
+            warningTimer = new LimitTimer(machine.ClockSource, frequency, this, "WWDTWarning", 0xFFFFFF, workMode: WorkMode.OneShot, enabled: false, eventEnabled: true, autoUpdate: true);
+            warningTimer.LimitReached += HandleWarning;
+
+            DefineRegisters();
+            Reset();
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+
+            timeoutTimer.Reset();
+            warningTimer.Reset();
+
+            watchdogEnabled = false;
+            watchdogResetEnabled = false;
+            timeoutFlag = false;
+            warningFlag = false;
+            timeoutValue = DefaultTimeoutValue;
+            warningValue = 0;
+            windowValue = DisabledWindowValue;
+            feedStage = FeedStage.None;
+
+            IRQ.Unset();
+        }
+
+        public GPIO IRQ { get; }
+
+        public long Size => 0x1000;
+
+        private void DefineRegisters()
+        {
+            Registers.Mode.Define(this)
+                .WithValueField(0, 8, name: "MOD",
+                    valueProviderCallback: _ => ComposeModeRegister(),
+                    writeCallback: (_, value) => WriteModeRegister((uint)value))
+                .WithReservedBits(8, 24);
+
+            Registers.TimeoutConstant.Define(this, DefaultTimeoutValue)
+                .WithValueField(0, 24, name: "TC",
+                    valueProviderCallback: _ => timeoutValue,
+                    writeCallback: (_, value) =>
+                    {
+                        timeoutValue = SanitizeTimeoutValue((uint)value);
+                        this.DebugLog("WWDT timeout constant updated to 0x{0:X6}", timeoutValue);
+                    })
+                .WithReservedBits(24, 8);
+
+            Registers.Feed.Define(this)
+                .WithValueField(0, 8, FieldMode.Write, name: "FEED",
+                    writeCallback: (_, value) => HandleFeed((byte)value))
+                .WithReservedBits(8, 24);
+
+            Registers.TimerValue.Define(this)
+                .WithValueField(0, 24, FieldMode.Read, name: "TV",
+                    valueProviderCallback: _ => GetCurrentTimerValue())
+                .WithReservedBits(24, 8);
+
+            Registers.WarningInterrupt.Define(this)
+                .WithValueField(0, 10, name: "WARNINT",
+                    valueProviderCallback: _ => warningValue,
+                    writeCallback: (_, value) => warningValue = (uint)value)
+                .WithReservedBits(10, 22);
+
+            Registers.Window.Define(this, DisabledWindowValue)
+                .WithValueField(0, 24, name: "WINDOW",
+                    valueProviderCallback: _ => windowValue,
+                    writeCallback: (_, value) => windowValue = (uint)value & TimerMask)
+                .WithReservedBits(24, 8);
+        }
+
+        private uint ComposeModeRegister()
+        {
+            var value = 0u;
+            value |= watchdogEnabled ? 1u << 0 : 0u;
+            value |= watchdogResetEnabled ? 1u << 1 : 0u;
+            value |= timeoutFlag ? 1u << 2 : 0u;
+            value |= warningFlag ? 1u << 3 : 0u;
+            return value;
+        }
+
+        private void WriteModeRegister(uint value)
+        {
+            if((value & (1u << 0)) != 0)
+            {
+                if(!watchdogEnabled)
+                {
+                    watchdogEnabled = true;
+                    this.DebugLog("WWDT enabled");
+                    ReloadWatchdog();
+                }
+            }
+            if((value & (1u << 1)) != 0)
+            {
+                watchdogResetEnabled = true;
+            }
+
+            if((value & (1u << 2)) != 0)
+            {
+                timeoutFlag = false;
+            }
+
+            if((value & (1u << 3)) != 0)
+            {
+                warningFlag = false;
+            }
+
+            UpdateInterrupts();
+        }
+
+        private void HandleFeed(byte value)
+        {
+            switch(feedStage)
+            {
+            case FeedStage.None:
+                feedStage = value == FirstFeedWord ? FeedStage.GotFirstWord : FeedStage.None;
+                return;
+
+            case FeedStage.GotFirstWord:
+                feedStage = FeedStage.None;
+                if(value == SecondFeedWord)
+                {
+                    RefreshWatchdog();
+                    return;
+                }
+
+                if(value == FirstFeedWord)
+                {
+                    feedStage = FeedStage.GotFirstWord;
+                }
+                break;
+            }
+        }
+
+        private void RefreshWatchdog()
+        {
+            if(!watchdogEnabled)
+            {
+                this.Log(LogLevel.Warning, "Ignoring WWDT refresh while watchdog is disabled");
+                return;
+            }
+
+            if(windowValue != DisabledWindowValue && GetCurrentTimerValue() > windowValue)
+            {
+                TriggerTimeout("Feed sequence performed outside the allowed WWDT window");
+                return;
+            }
+
+            ReloadWatchdog();
+        }
+
+        private void ReloadWatchdog()
+        {
+            var reloadValue = Math.Max(1u, timeoutValue);
+
+            timeoutTimer.Limit = reloadValue;
+            timeoutTimer.Value = reloadValue;
+            timeoutTimer.Enabled = watchdogEnabled;
+            timeoutTimer.EventEnabled = watchdogEnabled;
+
+            var warningDelay = CalculateWarningDelay(reloadValue);
+            warningTimer.Enabled = warningDelay.HasValue;
+            warningTimer.EventEnabled = warningDelay.HasValue;
+            if(warningDelay.HasValue)
+            {
+                warningTimer.Limit = warningDelay.Value;
+                warningTimer.Value = warningDelay.Value;
+            }
+
+            warningFlag = false;
+            UpdateInterrupts();
+        }
+
+        private uint? CalculateWarningDelay(uint reloadValue)
+        {
+            if(!watchdogEnabled || warningValue == 0)
+            {
+                return null;
+            }
+
+            var delay = reloadValue > warningValue ? reloadValue - warningValue + 1 : 1;
+            return Math.Max(1u, delay);
+        }
+
+        private uint GetCurrentTimerValue()
+        {
+            if(!watchdogEnabled)
+            {
+                return timeoutValue;
+            }
+
+            if(timeoutTimer.Enabled)
+            {
+                return (uint)timeoutTimer.Value & TimerMask;
+            }
+
+            return timeoutFlag ? 0u : timeoutValue;
+        }
+
+        private uint SanitizeTimeoutValue(uint value)
+        {
+            var masked = value & TimerMask;
+            return Math.Max(MinimumTimeoutValue, masked);
+        }
+
+        private void HandleWarning()
+        {
+            warningFlag = true;
+            this.DebugLog("WWDT warning interrupt asserted");
+            UpdateInterrupts();
+        }
+
+        private void HandleTimeout()
+        {
+            TriggerTimeout("WWDT timed out");
+        }
+
+        private void TriggerTimeout(string reason)
+        {
+            timeoutFlag = true;
+            timeoutTimer.Enabled = false;
+            warningTimer.Enabled = false;
+
+            this.Log(LogLevel.Warning, reason);
+            UpdateInterrupts();
+
+            if(watchdogResetEnabled)
+            {
+                machine.RequestReset();
+            }
+        }
+
+        private void UpdateInterrupts()
+        {
+            IRQ.Set(warningFlag);
+        }
+
+        private bool watchdogEnabled;
+        private bool watchdogResetEnabled;
+        private bool timeoutFlag;
+        private bool warningFlag;
+
+        private uint timeoutValue;
+        private uint warningValue;
+        private uint windowValue;
+
+        private FeedStage feedStage;
+
+        private readonly LimitTimer timeoutTimer;
+        private readonly LimitTimer warningTimer;
+
+        private const byte FirstFeedWord = 0xAA;
+        private const byte SecondFeedWord = 0x55;
+        private const uint TimerMask = 0x00FF_FFFF;
+        private const uint DisabledWindowValue = TimerMask;
+        private const uint DefaultTimeoutValue = TimerMask;
+        private const uint MinimumTimeoutValue = 0xFF;
+        private const ulong DefaultFrequency = 1;
+
+        private enum FeedStage
+        {
+            None,
+            GotFirstWord
+        }
+
+        private enum Registers : long
+        {
+            Mode = 0x0,
+            TimeoutConstant = 0x4,
+            Feed = 0x8,
+            TimerValue = 0xC,
+            WarningInterrupt = 0x14,
+            Window = 0x18
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/UART/NXP_FLEXCOMM.cs
+++ b/src/Emulator/Peripherals/Peripherals/UART/NXP_FLEXCOMM.cs
@@ -15,13 +15,15 @@ using Antmicro.Renode.Exceptions;
 using Antmicro.Renode.Logging;
 using Antmicro.Renode.Peripherals.Bus;
 using Antmicro.Renode.Peripherals.I2C;
+using Antmicro.Renode.Peripherals.SPI;
 using Antmicro.Renode.Utilities;
 
 namespace Antmicro.Renode.Peripherals.UART
 {
     public class NXP_FLEXCOMM : IKnownSize, IDoubleWordPeripheral, IProvidesRegisterCollection<DoubleWordRegisterCollection>, IUART,
         IPeripheralContainer<IUART, NullRegistrationPoint>,
-        IPeripheralContainer<II2CPeripheral, NumberRegistrationPoint<int>>
+        IPeripheralContainer<II2CPeripheral, NumberRegistrationPoint<int>>,
+        IPeripheralContainer<ISPIPeripheral, NumberRegistrationPoint<int>>
     {
         public NXP_FLEXCOMM(IMachine machine, uint uartFifoSize = 256, bool uartPresent = true, bool i2cPresent = true, bool spiPresent = true)
         {
@@ -47,15 +49,21 @@ namespace Antmicro.Renode.Peripherals.UART
             i2cInstance = new S32K3XX_LowPowerInterIntegratedCircuit(machine);
             i2cInstance.IRQ.AddStateChangedHook((state) => UpdateI2CMasterGPIO(PeripheralMode.I2C, state));
 
+            spiInstance = new IMXRT_LPSPI(machine);
+            spiInstance.IRQ.AddStateChangedHook((state) => UpdateSPIGPIO(PeripheralMode.SPI, state));
+
             DefineRegisters();
             Reset();
         }
 
         public void Reset()
         {
-            IRQ.Unset();
             uartInstance.Reset();
+            i2cInstance.Reset();
+            spiInstance.Reset();
+            currentPeripheralMode = PeripheralMode.None;
             RegistersCollection.Reset();
+            UpdateCombinedIRQ();
         }
 
         public uint ReadDoubleWord(long offset)
@@ -71,6 +79,10 @@ namespace Antmicro.Renode.Peripherals.UART
             else if(currentPeripheralMode == PeripheralMode.I2C)
             {
                 return i2cInstance.ReadDoubleWord(GetI2CRegistersOffset(offset));
+            }
+            else if(currentPeripheralMode == PeripheralMode.SPI)
+            {
+                return spiInstance.ReadDoubleWord(offset);
             }
             else
             {
@@ -92,6 +104,10 @@ namespace Antmicro.Renode.Peripherals.UART
             else if(currentPeripheralMode == PeripheralMode.I2C)
             {
                 i2cInstance.WriteDoubleWord(GetI2CRegistersOffset(offset), value);
+            }
+            else if(currentPeripheralMode == PeripheralMode.SPI)
+            {
+                spiInstance.WriteDoubleWord(offset, value);
             }
             else
             {
@@ -135,6 +151,22 @@ namespace Antmicro.Renode.Peripherals.UART
             return i2cInstance.GetRegistrationPoints(peripheral);
         }
 
+        public virtual void Register(ISPIPeripheral peripheral, NumberRegistrationPoint<int> registrationPoint)
+        {
+            EnsureChildPeripheralRegistered(spiInstance, $"{machine.GetLocalName(this)}_spi");
+            spiInstance.Register(peripheral, registrationPoint);
+        }
+
+        public virtual void Unregister(ISPIPeripheral peripheral)
+        {
+            spiInstance.Unregister(peripheral);
+        }
+
+        public IEnumerable<NumberRegistrationPoint<int>> GetRegistrationPoints(ISPIPeripheral peripheral)
+        {
+            return spiInstance.GetRegistrationPoints(peripheral);
+        }
+
         public void UpdateTxGPIO(PeripheralMode source, bool state)
         {
             switch(source)
@@ -151,7 +183,7 @@ namespace Antmicro.Renode.Peripherals.UART
             }
             }
 
-            IRQ.Set(state);
+            UpdateCombinedIRQ();
         }
 
         public void UpdateRxGPIO(PeripheralMode source, bool state)
@@ -170,7 +202,7 @@ namespace Antmicro.Renode.Peripherals.UART
             }
             }
 
-            IRQ.Set(uartTxInterruptSet.Value || uartRxInterruptSet.Value);
+            UpdateCombinedIRQ();
         }
 
         public void UpdateI2CMasterGPIO(PeripheralMode source, bool state)
@@ -189,7 +221,26 @@ namespace Antmicro.Renode.Peripherals.UART
             }
             }
 
-            IRQ.Set(state);
+            UpdateCombinedIRQ();
+        }
+
+        public void UpdateSPIGPIO(PeripheralMode source, bool state)
+        {
+            switch(source)
+            {
+            case PeripheralMode.SPI:
+            {
+                spiInterruptSet.Value = state;
+                break;
+            }
+            default:
+            {
+                this.Log(LogLevel.Error, $"Unsupported FLEXCOMM mode: {currentPeripheralMode} - ignoring IRQ.");
+                return;
+            }
+            }
+
+            UpdateCombinedIRQ();
         }
 
         public GPIO IRQ { get; }
@@ -211,6 +262,8 @@ namespace Antmicro.Renode.Peripherals.UART
 
         IEnumerable<IRegistered<II2CPeripheral, NumberRegistrationPoint<int>>> IPeripheralContainer<II2CPeripheral, NumberRegistrationPoint<int>>.Children => i2cInstance.Children;
 
+        IEnumerable<IRegistered<ISPIPeripheral, NumberRegistrationPoint<int>>> IPeripheralContainer<ISPIPeripheral, NumberRegistrationPoint<int>>.Children => spiInstance.Children;
+
         private static bool IsFlexcommRegister(long offset)
         {
             return offset == (long)Registers.InterruptStatus || offset == (long)Registers.PeripheralSelectAndID;
@@ -226,7 +279,7 @@ namespace Antmicro.Renode.Peripherals.UART
             if(!machine.IsRegistered(peripheral))
             {
                 machine.RegisterAsAChildOf(this, peripheral, NullRegistrationPoint.Instance);
-                machine.SetLocalName(i2cInstance, name);
+                machine.SetLocalName(peripheral, name);
             }
         }
 
@@ -264,6 +317,33 @@ namespace Antmicro.Renode.Peripherals.UART
             }
 
             currentPeripheralMode = newMode;
+            UpdateCombinedIRQ();
+        }
+
+        private void UpdateCombinedIRQ()
+        {
+            var irqState = false;
+
+            switch(currentPeripheralMode)
+            {
+            case PeripheralMode.UART:
+            case PeripheralMode.UARTI2C:
+                irqState = uartTxInterruptSet.Value || uartRxInterruptSet.Value;
+                break;
+            case PeripheralMode.I2C:
+                irqState = i2cMasterInterruptSet.Value;
+                break;
+            case PeripheralMode.SPI:
+                irqState = spiInterruptSet.Value;
+                break;
+            case PeripheralMode.None:
+                break;
+            default:
+                this.Log(LogLevel.Warning, $"Unsupported FLEXCOMM mode: {currentPeripheralMode} - deasserting IRQ.");
+                break;
+            }
+
+            IRQ.Set(irqState);
         }
 
         private void DefineRegisters()
@@ -285,7 +365,7 @@ namespace Antmicro.Renode.Peripherals.UART
             Registers.InterruptStatus.Define(this)
                     .WithFlag(0, out uartTxInterruptSet, mode: FieldMode.Read, name: "UARTTX")
                     .WithFlag(1, out uartRxInterruptSet, mode: FieldMode.Read, name: "UARTRX")
-                    .WithTaggedFlag("SPI", 2)
+                    .WithFlag(2, out spiInterruptSet, mode: FieldMode.Read, name: "SPI")
                     .WithReservedBits(3, 1)
                     .WithFlag(4, out i2cMasterInterruptSet, mode: FieldMode.Read, name: "I2CM")
                     .WithTaggedFlag("I2CS", 5)
@@ -308,6 +388,7 @@ namespace Antmicro.Renode.Peripherals.UART
         private PeripheralMode currentPeripheralMode;
         private IFlagRegisterField uartTxInterruptSet;
         private IFlagRegisterField uartRxInterruptSet;
+        private IFlagRegisterField spiInterruptSet;
         private IFlagRegisterField i2cMasterInterruptSet;
         private IFlagRegisterField peripheralModeLock;
 
@@ -321,6 +402,7 @@ namespace Antmicro.Renode.Peripherals.UART
         private readonly NullRegistrationPointContainerHelper<IUART> uartContainer;
 
         private readonly S32K3XX_LowPowerInterIntegratedCircuit i2cInstance;
+        private readonly IMXRT_LPSPI spiInstance;
 
         private const long I2CRegistersOffset = 0x800;
 


### PR DESCRIPTION
### Related issue

renode/renode#970

### Description

This PR adds the peripheral models required for initial NXP MCXN947 support:

* corrects LPSPI data-match IRQ gating and recomputes IRQ state after W1C status writes;
* enables SPI registration, register routing, status, reset, and shared IRQ handling in `NXP_FLEXCOMM`;
* adds the MCXN94 GPIO/PORT register model with stored output data and dual routed IRQs;
* adds the MCXN94 WWDT warning, refresh, window, IRQ, and reset behavior;
* adds the MCXN94 CDOG instruction timer, secure-counter commands, fault controls, sticky flags, IRQ/reset behavior, and deterministic fault-injection methods.

The commits are intentionally separated by peripheral/model boundary. Each commit was compiled independently.

### Usage example

The follow-up Renode PR will add `platforms/cpus/mcxn947.repl`, the FRDM-MCXN947 board description, and a firmware-free Robot suite that exercises reset, GPIO, IRQ, SPI, I2C, WWDT, and CDOG fault paths.

### Verification

* Managed Renode solution build: passed.
* `dotnet format --verify-no-changes`: passed for all five changed files.
* Infrastructure peripheral tests: 100 passed, 5 skipped.
* Follow-up MCXN947 Robot suite: 8 passed.
* `git diff --check`: passed.
* Every commit in this PR was compiled in isolation.

### Additional information

This is initial peripheral-focused support. GPIO DMA requests and functional pin-mux routing, LPI2C target mode, LPSPI slave mode, clock-tree switching, and advanced CDOG state/address fault integration remain outside this PR.

CDOG fault flags and persistent data intentionally survive software reset, matching NXP's documented behavior. Renode currently has no distinct power-on-reset path for this peripheral.
