### PR TITLE
MCAN: Fix Tx Event FIFO full flag never being set

### DIFF
--- a/src/Emulator/Peripherals/Peripherals/CAN/MCAN.cs
+++ b/src/Emulator/Peripherals/Peripherals/CAN/MCAN.cs
@@ -806,7 +806,7 @@ namespace Antmicro.Renode.Peripherals.CAN
             messageRAM.WriteBytes((long)addr, txFIFOElementBytes, 0, txFIFOElementBytes.Length);
 
             txEventFIFO.PutIndex += 1;
-            txEventFIFO.Full.Value = txEventFIFO.PutIndexRaw == txEventFIFO.GetIndexRaw;
+            txEventFIFO.Full.Value = txEventFIFO.PutIndex == txEventFIFO.GetIndex;
 
             var watermarkReached = (txEventFIFO.Watermark.Value > 0) && (txEventFIFO.FillLevel >= txEventFIFO.Watermark.Value);
             if(watermarkReached)


### PR DESCRIPTION
StoreInTxEventFIFO decided whether the Tx Event FIFO had become full by comparing PutIndexRaw against GetIndexRaw. Those are IValueRegisterField references, so the comparison is always false and Full is never set.

Once the FIFO wraps (the put index returns to the get index), FillLevel takes the PutIndexRaw.Value >= GetIndexRaw.Value branch and computes 0 - 0 == 0, so TXEFS.EFFL reads as empty while the FIFO actually holds Size elements.

The Rx path already does this correctly at the equivalent place, using the ulong wrapper properties instead of the raw fields:

    rxFIFO.Full.Value = rxFIFO.RxFIFOPutIndex == rxFIFO.RxFIFOGetIndex;

This change makes the Tx Event FIFO match that.

Impact: any driver that reclaims Tx buffers through the Tx Event FIFO stalls after exactly TXEFC.EFS frames. Zephyr's can_mcan driver does exactly that - can_mcan_tx_event_handler() loops on TXEFS.EFFL, finds zero, and returns without releasing any Tx buffer, so tx_sem is never given back and every subsequent can_send() returns -EAGAIN forever.

Reproduced on an STM32H725 platform (three FDCAN instances using CAN.MCAN, bosch,mram-cfg giving 3 dedicated Tx buffers and a 3-element Tx Event FIFO) running Zephyr 4.4.2. Frames transmitted by one instance over 3 seconds of emulated time:

    before: 3
    after:  14874

Bare-metal firmware using the Tx FIFO/Queue path is unaffected, since it never reads the Tx Event FIFO - which is presumably why this went unnoticed.