### PR TITLE
[#978] GdbStub: Send exactly one stop reply per resume

### DIFF
--- a/src/Emulator/Main/Utilities/GDB/GdbStub.cs
+++ b/src/Emulator/Main/Utilities/GDB/GdbStub.cs
@@ -178,12 +178,16 @@ namespace Antmicro.Renode.Utilities.GDB
                 else
                 {
                     IEnumerable<PacketData> packetDatas;
+                    // The CPU can halt before `Execute` returns, so the reply has to be expected
+                    // before dispatching and unexpected again if the command answers on its own.
+                    ExpectStopReply();
                     try
                     {
                         packetDatas = Command.Execute(command, result.Packet);
                     }
                     catch(Exception e)
                     {
+                        ConsumeStopReply();
                         if(e.InnerException is InvalidRegisterAccessException)
                         {
                             ctx.Send(new Packet(PacketData.ErrorReply(Error.OperationNotPermitted)));
@@ -209,6 +213,10 @@ namespace Antmicro.Renode.Utilities.GDB
                     }
 
                     // If there is no data here, we will respond later with Stop Reply Response
+                    if(packetDatas.Any())
+                    {
+                        ConsumeStopReply();
+                    }
                     foreach(var packetData in packetDatas)
                     {
                         ctx.Send(new Packet(packetData));
@@ -240,11 +248,11 @@ namespace Antmicro.Renode.Utilities.GDB
                         if(commandsManager.Machine.SystemBus.IsMultiCore)
                         {
                             commandsManager.SelectCpuForDebugging(cpuSupportingGdb);
-                            ctx.Send(new Packet(PacketData.StopReply(args.BreakpointType.Value, commandsManager.ManagedCpus[cpuSupportingGdb], args.Address)));
+                            SendStopReply(ctx, PacketData.StopReply(args.BreakpointType.Value, commandsManager.ManagedCpus[cpuSupportingGdb], args.Address));
                         }
                         else
                         {
-                            ctx.Send(new Packet(PacketData.StopReply(args.BreakpointType.Value, args.Address)));
+                            SendStopReply(ctx, PacketData.StopReply(args.BreakpointType.Value, args.Address));
                         }
                         break;
                     }
@@ -262,23 +270,31 @@ namespace Antmicro.Renode.Utilities.GDB
                         if(sendStopResponse)
                         {
                             commandsManager.SelectCpuForDebugging(cpuSupportingGdb);
-                            ctx.Send(new Packet(PacketData.StopReply(InterruptSignal, commandsManager.ManagedCpus[cpuSupportingGdb])));
+                            SendStopReply(ctx, PacketData.StopReply(InterruptSignal, commandsManager.ManagedCpus[cpuSupportingGdb]));
                         }
                     }
                     else
                     {
-                        ctx.Send(new Packet(PacketData.StopReply(InterruptSignal)));
+                        SendStopReply(ctx, PacketData.StopReply(InterruptSignal));
                     }
                     return;
                 case HaltReason.Step:
+                    // A single-stepping CPU reports itself as halted every time it enters the wait
+                    // for the next step command, not once per completed step, so only the report
+                    // that answers a resume is a stop. Sending the rest would desync the session:
+                    // the surplus packet is read as the answer to the next resume.
+                    if(!ConsumeStopReply())
+                    {
+                        return;
+                    }
                     if(commandsManager.Machine.SystemBus.IsMultiCore)
                     {
                         commandsManager.SelectCpuForDebugging(cpuSupportingGdb);
-                        ctx.Send(new Packet(PacketData.StopReply(TrapSignal, commandsManager.ManagedCpus[cpuSupportingGdb])));
+                        SendStopReply(ctx, PacketData.StopReply(TrapSignal, commandsManager.ManagedCpus[cpuSupportingGdb]));
                     }
                     else
                     {
-                        ctx.Send(new Packet(PacketData.StopReply(TrapSignal)));
+                        SendStopReply(ctx, PacketData.StopReply(TrapSignal));
                     }
                     return;
                 case HaltReason.Abort:
@@ -288,6 +304,36 @@ namespace Antmicro.Renode.Utilities.GDB
                     throw new ArgumentException("Unexpected halt reason");
                 }
             }
+        }
+
+        // Commands that resume the CPU are answered by an asynchronous Stop Reply sent from
+        // `OnHalted`, and exactly one is owed per resume. The CPU may however report being halted
+        // several times for a single stop, so the surplus reports have to be dropped.
+        private void ExpectStopReply()
+        {
+            lock(stopReplyLock)
+            {
+                stopReplyOwed = true;
+            }
+        }
+
+        // Whether a reply was owed, and no longer is.
+        private bool ConsumeStopReply()
+        {
+            lock(stopReplyLock)
+            {
+                var owed = stopReplyOwed;
+                stopReplyOwed = false;
+                return owed;
+            }
+        }
+
+        // Sending is what settles the debt, rather than reaching `OnHalted`: the branches that
+        // report nothing leave the reply owed, so a later halt can still answer the resume.
+        private void SendStopReply(CommunicationHandler.Context ctx, PacketData data)
+        {
+            ConsumeStopReply();
+            ctx.Send(new Packet(data));
         }
 
         private void OnConnectionAccepted()
@@ -303,6 +349,7 @@ namespace Antmicro.Renode.Utilities.GDB
 
         private void OnConnectionClosed()
         {
+            ConsumeStopReply();
             foreach(var cpu in commandsManager.ManagedCpus)
             {
                 cpu.Halted -= OnHalted;
@@ -313,8 +360,10 @@ namespace Antmicro.Renode.Utilities.GDB
         }
 
         private ICpuSupportingGdb stopReplyingCpu;
+        private bool stopReplyOwed;
         private bool disconnectedState;
 
+        private readonly object stopReplyLock = new object();
         private readonly PacketBuilder pcktBuilder;
         private readonly IEnumerable<ICpuSupportingGdb> cpus;
         private readonly SocketServerProvider terminal;


### PR DESCRIPTION
### Related issue

renode/renode#978

### Description

This is a **bug fix**.

For every stop, the GDB stub put two stop-reply packets on the wire instead of one: a breakpoint
sent `T05hwbreak:;` and was immediately followed by a generic `S05`, a plain `s` was answered by two
`S05`, and attaching produced a reply although the client had not resumed anything yet.

`GdbStub.OnConnectionAccepted` puts every managed CPU into `ExecutionMode.SingleStep`. The
single-step wait in `BaseCPU.CpuThreadBody` then reports the CPU as halted *every time it enters the
wait* — not once per completed step, and once more on each pass when `WaitForStepCommand` returns
false:

```csharp
// BaseCPU.cs
InvokeHalted(new HaltArguments(HaltReason.Step, this));
if(!singleStepSynchronizer.WaitForStepCommand(out stepResult))
{
    this.Trace();
    continue;
}
```

`OnHalted` turned each of those reports into a stop reply unconditionally.

GDB drains unexpected stop replies and is unaffected. LLDB is not: it reads the precise reply, stops,
and leaves the stray `S05` buffered, so its next resume reads that stale packet as the answer. With
`process handle SIGTRAP --stop false` the session silently auto-resumes and the target runs away;
without it, LLDB reports a spurious `signal SIGTRAP` frame. Either way the first breakpoint appears
to work and nothing after it does.

**The change.** The stub already knows when a stop reply is owed: every command that resumes the
machine (`c`, `s`, `vCont`, `vRun`, the reverse-execution commands) returns no packet data of its own
and is answered later from `OnHalted` — the existing
`// If there is no data here, we will respond later with Stop Reply Response` path. Those are exactly
the commands for which `Command.Execute` yields an empty sequence. This makes that state explicit
rather than adding a new one:

* `ExpectStopReply()` before dispatching a command, undone if the command answers synchronously. It
  is armed *before* `Execute` because a resumed CPU can halt before `Execute` returns.
* Every stop reply sent from `OnHalted` goes through `SendStopReply`, which consumes the
  expectation. A breakpoint therefore silences the single-step report that follows it.
* A `HaltReason.Step` report is dropped when no expectation is outstanding: it marks the CPU
  entering the single-step wait, not a stop the client is waiting on.
* The expectation is cleared when the client disconnects, so it cannot leak into the next session.

Consuming the expectation is tied to the *send* rather than to reaching `OnHalted`, so the branches
that deliberately report nothing — an internal pause during a reset, a breakpoint type the switch
does not match — leave the reply owed and a later halt can still answer the resume.

`BaseCPU`'s stepping loop is deliberately left alone: it is core execution logic shared by every
architecture, and the packet count is the stub's business.

### Usage example

I did not create a repository from the issue reproduction template, because this needs no binary at
all — a bare Cortex-M platform, the GDB stub and one raw `$s#73` packet are enough, with the `repl`
and `resc` generated inline. The full script is in renode/renode#978 and runs against any Renode
build:

```
# before
step 1 -> ['S05', 'S05'] (expected exactly one stop reply, got 2)
step 2 -> ['S05', 'S05'] (expected exactly one stop reply, got 2)

# after
step 1 -> ['S05'] (expected exactly one stop reply, got 1)
step 2 -> ['S05'] (expected exactly one stop reply, got 1)
```

Driving the stub over a raw socket with a real ELF and a hardware breakpoint on a loop, against
`1.16.1+20260827git824b95097`:

| step | before | after |
|---|---|---|
| on attach | `['S05']` | `[]` |
| `Z1,<loop>,2` | `['OK']` | `['OK']` |
| `c` | `['T05hwbreak:;', 'S05']` | `['T05hwbreak:;']` |
| `s` | `['S05', 'S05']` | `['S05']` |

End to end with LLDB (CodeLLDB's, connected asynchronously the way an editor drives it), two
breakpoints in the same function plus a `next`:

* before: the first breakpoint is reported, then the next resume surfaces
  `stop reason = signal SIGTRAP` at a bogus frame and the target runs to completion;
* after: it stops at each breakpoint in turn and `next` advances one line, as written.

`qRcmd` is the only command that answers with more than one packet, so it was checked separately:
its two packets are unchanged, and a following `s` is answered once instead of twice.

### Additional information

**A behavioural change to be aware of.** The `HaltReason.Step` branch previously sent a reply for
every CPU that reported a step halt; with a single expectation per resume, the first reporting CPU
answers and the others are dropped. `QNonStop` is not implemented and `MultithreadContinueCommand`
states that only all-stop is supported, so one reply per resume should be what is wanted — but I
have only been able to test single-core.

This also looks like the same defect noted at `MultithreadContinueCommand.cs:92` ("Switching the
core into SingleStep will cause a spurious StopReply to be sent to Gdb / TODO: this should be
addressed"). That path sends fewer surplus packets now but is not fully closed: the mode switch
happens while `vCont;` is still executing, so the premature reply consumes the expectation.