### PR TITLE
[FIX] USBDeviceCore: Prevent NullReferenceException on STALL setup response

### DIFF
--- a/src/Emulator/Main/Peripherals/USB/USBDeviceCore.cs
+++ b/src/Emulator/Main/Peripherals/USB/USBDeviceCore.cs
@@ -194,10 +194,17 @@ namespace Antmicro.Renode.Core.USB
 
         private void SendSetupResult(Action<byte[]> resultCallback, byte[] result)
         {
-            device.Log(LogLevel.Noisy, "Sending setup packet response of length {0}", result.Length);
+            if(result != null)
+            {
+                device.Log(LogLevel.Noisy, "Sending setup packet response of length {0}", result.Length);
 #if DEBUG_PACKET
-            device.Log(LogLevel.Noisy, Misc.PrettyPrintCollectionHex(result));
+                device.Log(LogLevel.Noisy, Misc.PrettyPrintCollectionHex(result));
 #endif
+            }
+            else
+            {
+                device.Log(LogLevel.Noisy, "Sending setup packet STALL response");
+            }
             resultCallback(result);
         }
 

--- a/src/Emulator/Main/Tests/UnitTests/USBDeviceCoreTests.cs
+++ b/src/Emulator/Main/Tests/UnitTests/USBDeviceCoreTests.cs
@@ -1,0 +1,62 @@
+//
+// Copyright (c) 2010-2026 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using Antmicro.Renode.Core.Structure;
+using Antmicro.Renode.Core.USB;
+using Antmicro.Renode.Peripherals;
+using NUnit.Framework;
+
+namespace Antmicro.Renode.UnitTests
+{
+    [TestFixture]
+    public class USBDeviceCoreTests
+    {
+        [Test]
+        public void ShouldHandleStallSetupPacketWithoutException()
+        {
+            var dummyDevice = new DummyUSBDevice((packet, data, callback) =>
+            {
+                // Simulate a STALL response by passing null to the result callback
+                callback(null);
+            });
+
+            byte[] receivedResult = new byte[] { 0xDE, 0xAD };
+            var setupPacket = new SetupPacket
+            {
+                Recipient = PacketRecipient.Device,
+                Type = PacketType.Vendor,
+                Direction = Direction.HostToDevice,
+                Request = 0x42
+            };
+
+            Assert.DoesNotThrow(() =>
+            {
+                dummyDevice.USBCore.HandleSetupPacket(setupPacket, result =>
+                {
+                    receivedResult = result;
+                });
+            });
+
+            Assert.IsNull(receivedResult);
+        }
+
+        private class DummyUSBDevice : IUSBDevice
+        {
+            public DummyUSBDevice(Action<SetupPacket, byte[], Action<byte[]>> customSetupHandler = null)
+            {
+                USBCore = new USBDeviceCore(this, customSetupPacketHandler: customSetupHandler);
+            }
+
+            public void Reset()
+            {
+                USBCore.Reset();
+            }
+
+            public USBDeviceCore USBCore { get; }
+        }
+    }
+}


### PR DESCRIPTION
### Description

When a USB setup packet is rejected or stalled by a device model (returning null or STALL status), `USBDeviceCore.SendSetupResult` could encounter an unhandled null response, leading to a `NullReferenceException`.

This fix adds a null guard in `SendSetupResult` to gracefully handle STALL/unsupported setup requests without throwing exceptions and adds a dedicated unit test suite.

### Commit Series

1. `[FIX] USBDeviceCore: Prevent NullReferenceException on STALL setup response` (includes `USBDeviceCoreTests.cs`)

### Additional information

- Tested against all USB device models in Renode (`USBPendrive`, `USBKeyboard`, `USBMouse`, `ArduinoLoader`, `NRF_USBD`).
- Unit test suite `USBDeviceCoreTests.cs` verifies safe handling of STALL setup requests.