### PR TITLE
[FIX] USBIPServer: Reliability improvements, async endpoint reads, and spec compliance

### DIFF
--- a/src/Emulator/Extensions/Utilities/USBIP/USBIPServer.cs
+++ b/src/Emulator/Extensions/Utilities/USBIP/USBIPServer.cs
@@ -85,9 +85,14 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
             cancellationToken = new CancellationTokenSource();
         }
 
+        private readonly object sendLock = new object();
+
         private void SendResponse(IEnumerable<byte> bytes)
         {
-            server.Send(bytes);
+            lock(sendLock)
+            {
+                server.Send(bytes);
+            }
 
 #if DEBUG_PACKETS
             this.Log(LogLevel.Noisy, "Count {0}: {1}", bytes.Count(), Misc.PrettyPrintCollectionHex(bytes));
@@ -256,12 +261,25 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
                     }
                     else if(ep.Direction == Direction.DeviceToHost)
                     {
-                        this.Log(LogLevel.Noisy, "Reading from endpoint #{0}", ep.Identifier);
-                        var response = ep.Read(packet.TransferBufferLength, cancellationToken.Token);
-#if DEBUG_PACKETS
-                            this.Log(LogLevel.Noisy, "Count {0}: {1}", response.Length, Misc.PrettyPrintCollectionHex(response));
-#endif
-                        SendResponse(GenerateURBReply(urbHeader, packet, response));
+                        var capturedUrbHeader = urbHeader;
+                        var capturedPacket = packet;
+                        var capturedToken = cancellationToken.Token;
+                        ThreadPool.QueueUserWorkItem(_ =>
+                        {
+                            try
+                            {
+                                this.Log(LogLevel.Noisy, "Reading from endpoint #{0}", ep.Identifier);
+                                var response = ep.Read(capturedPacket.TransferBufferLength, capturedToken);
+                                SendResponse(GenerateURBReply(capturedUrbHeader, capturedPacket, response));
+                            }
+                            catch(OperationCanceledException)
+                            {
+                            }
+                            catch(Exception ex)
+                            {
+                                this.Log(LogLevel.Warning, "Exception during ep.Read: {0}", ex.Message);
+                            }
+                        });
                     }
                     else
                     {

--- a/src/Emulator/Extensions/Utilities/USBIP/USBIPServer.cs
+++ b/src/Emulator/Extensions/Utilities/USBIP/USBIPServer.cs
@@ -249,7 +249,14 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
                     var replyHeader = urbHeader;
                     device.USBCore.HandleSetupPacket(setupPacket, additionalData: additionalData, resultCallback: response =>
                     {
-                        SendResponse(GenerateURBReply(replyHeader, packet, response));
+                        if(response == null)
+                        {
+                            SendResponse(GenerateURBReply(replyHeader, packet, null, status: -32));
+                        }
+                        else
+                        {
+                            SendResponse(GenerateURBReply(replyHeader, packet, response, status: 0));
+                        }
                     });
                 }
                 else
@@ -314,7 +321,7 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
             }
         }
 
-        private IEnumerable<byte> GenerateURBReply(URBHeader hdr, URBRequest req, IEnumerable<byte> data = null)
+        private IEnumerable<byte> GenerateURBReply(URBHeader hdr, URBRequest req, IEnumerable<byte> data = null, int status = 0)
         {
             var header = new URBHeader
             {
@@ -324,20 +331,19 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
                 DeviceId = hdr.DeviceId,
                 Direction = hdr.Direction,
                 EndpointNumber = hdr.EndpointNumber,
+                FlagsOrStatus = (uint)status,
             };
 
             var reply = new URBReply
             {
-                // this is intentional:
-                // - report size of TransferBufferLength when returning no additional data,
-                // - report additional data size (and not TransferBufferLenght) otherwise
-                ActualLength = (data == null)
+                ActualLength = (status != 0) ? 0 : ((hdr.Direction == URBDirection.Out)
                     ? req.TransferBufferLength
-                    : (uint)data.Count()
+                    : (uint)(data?.Count() ?? 0)),
+                Setup = req.Setup
             };
 
             var result = Packet.Encode(header).Concat(Packet.Encode(reply)).AsEnumerable();
-            if(data != null)
+            if(hdr.Direction == URBDirection.In && data != null && status == 0)
             {
                 result = result.Concat(data);
             }

--- a/src/Emulator/Extensions/Utilities/USBIP/USBIPServer.cs
+++ b/src/Emulator/Extensions/Utilities/USBIP/USBIPServer.cs
@@ -354,7 +354,7 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
         // using this blocking helper method simplifies the logic of other methods
         // + it seems to be harmless, as this logic is not executed as a result of
         // intra-emulation communication (where it could lead to deadlocks)
-        private byte[] HandleSetupPacketSync(IUSBDevice device, SetupPacket setupPacket)
+        private byte[] HandleSetupPacketSync(IUSBDevice device, SetupPacket setupPacket, int timeoutMs = 1500)
         {
             byte[] result = null;
 
@@ -365,7 +365,10 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
                 mre.Set();
             });
 
-            mre.WaitOne();
+            if(!mre.WaitOne(timeoutMs))
+            {
+                this.Log(LogLevel.Warning, "Timeout waiting for setup packet response: {0}", setupPacket.ToString());
+            }
             return result;
         }
 
@@ -381,7 +384,10 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
                 Count = (ushort)Packet.CalculateLength<USB.DeviceDescriptor>()
             };
 
-            return Packet.Decode<USB.DeviceDescriptor>(HandleSetupPacketSync(device, setupPacket));
+            var data = HandleSetupPacketSync(device, setupPacket, 1000);
+            return data != null && data.Length >= Packet.CalculateLength<USB.DeviceDescriptor>()
+                ? Packet.Decode<USB.DeviceDescriptor>(data)
+                : default(USB.DeviceDescriptor);
         }
 
         private USB.ConfigurationDescriptor ReadConfigurationDescriptor(IUSBDevice device, byte configurationId, out USB.InterfaceDescriptor[] interfaceDescriptors)
@@ -396,23 +402,37 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
                 Count = (ushort)Packet.CalculateLength<USB.ConfigurationDescriptor>()
             };
             // first ask for the configuration descriptor non-recursively ...
-            var configurationDescriptorBytes = HandleSetupPacketSync(device, setupPacket);
+            var configurationDescriptorBytes = HandleSetupPacketSync(device, setupPacket, 1000);
+            if(configurationDescriptorBytes == null || configurationDescriptorBytes.Length < Packet.CalculateLength<USB.ConfigurationDescriptor>())
+            {
+                interfaceDescriptors = Array.Empty<USB.InterfaceDescriptor>();
+                return default(USB.ConfigurationDescriptor);
+            }
             var result = Packet.Decode<USB.ConfigurationDescriptor>(configurationDescriptorBytes);
 
             interfaceDescriptors = new USB.InterfaceDescriptor[result.NumberOfInterfaces];
             // ... read the total length of a recursive structure ...
             setupPacket.Count = result.TotalLength;
             // ... and only then read the whole structure again.
-            var recursiveBytes = HandleSetupPacketSync(device, setupPacket);
+            var recursiveBytes = HandleSetupPacketSync(device, setupPacket, 1000);
+            if(recursiveBytes == null || recursiveBytes.Length < result.TotalLength)
+            {
+                interfaceDescriptors = Array.Empty<USB.InterfaceDescriptor>();
+                return result;
+            }
 
             var currentOffset = Packet.CalculateLength<USB.ConfigurationDescriptor>();
             for(var i = 0; i < interfaceDescriptors.Length; i++)
             {
                 // the second byte of each descriptor contains the type
-                while(recursiveBytes[currentOffset + 1] != (byte)DescriptorType.Interface)
+                while(currentOffset + 1 < recursiveBytes.Length && recursiveBytes[currentOffset + 1] != (byte)DescriptorType.Interface)
                 {
                     // the first byte of each descriptor contains the length in bytes
                     currentOffset += recursiveBytes[currentOffset];
+                }
+                if(currentOffset >= recursiveBytes.Length)
+                {
+                    break;
                 }
 
                 interfaceDescriptors[i] = Packet.Decode<USB.InterfaceDescriptor>(recursiveBytes, currentOffset);

--- a/src/Emulator/Extensions/Utilities/USBIP/USBIPServer.cs
+++ b/src/Emulator/Extensions/Utilities/USBIP/USBIPServer.cs
@@ -36,7 +36,7 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
         }
 
         // this is just a simple wrapper method allowing to register devices from monitor
-        public static void Register(this USBIPServer @this, IUSBDevice device, int? port = null)
+        public static void Register(this USBIPServer @this, IUSBDevice device, int? port = null, USBSpeed? speed = null)
         {
             if(!port.HasValue)
             {
@@ -45,12 +45,21 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
                     : 0;
             }
 
+            if(speed.HasValue)
+            {
+                @this.SetDeviceSpeed(device, speed.Value);
+            }
+
             @this.Register(device, new NumberRegistrationPoint<int>(port.Value));
         }
     }
 
     public class USBIPServer : SimpleContainerBase<IUSBDevice>, IHostMachineElement, IDisposable
     {
+        public void SetDeviceSpeed(IUSBDevice device, USBSpeed speed)
+        {
+            deviceSpeeds[device] = speed;
+        }
         public USBIPServer(int port)
         {
             this.port = port;
@@ -457,6 +466,12 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
                 }
             }
 
+            USBSpeed speed;
+            if(!deviceSpeeds.TryGetValue(device, out speed))
+            {
+                speed = device.USBCore?.Speed ?? USBSpeed.Full;
+            }
+
             var devDescriptor = new USBIP.DeviceDescriptor
             {
                 Path = new byte[256],
@@ -464,7 +479,7 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
 
                 BusNumber = ExportedBusId,
                 DeviceNumber = deviceNumber,
-                Speed = (int)USBSpeed.High, // this is hardcoded, but I don't know if that's good
+                Speed = (uint)speed,
 
                 IdVendor = deviceDescriptor.VendorId,
                 IdProduct = deviceDescriptor.ProductId,
@@ -531,7 +546,6 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
             var success = true;
             var deviceId = 0;
             IUSBDevice device = null;
-
             var m = Regex.Match(deviceIdString, "([0-9]+)-([0-9]+)");
             if(m == null)
             {
@@ -579,20 +593,10 @@ namespace Antmicro.Renode.Extensions.Utilities.USBIP
         private readonly int port;
         private readonly List<byte> buffer;
         private readonly SocketServerProvider server;
+        private readonly Dictionary<IUSBDevice, USBSpeed> deviceSpeeds = new Dictionary<IUSBDevice, USBSpeed>();
 
         private const uint ExportedBusId = 1;
         private const ushort ProtocolVersion = 0x0111;
-
-        private enum USBSpeed
-        {
-            Unknown = 0,
-            Low = 1,
-            Full = 2,
-            High = 3,
-            Wireless = 4,
-            Super = 5,
-            SuperPlus = 6,
-        }
 
         private enum State
         {

--- a/src/Emulator/Main/Peripherals/USB/USBDeviceCore.cs
+++ b/src/Emulator/Main/Peripherals/USB/USBDeviceCore.cs
@@ -28,7 +28,8 @@ namespace Antmicro.Renode.Core.USB
                              string serialNumber = null,
                              ushort vendorId = 0,
                              ushort productId = 0,
-                             Action<SetupPacket, byte[], Action<byte[]>> customSetupPacketHandler = null) : base(18, (byte)DescriptorType.Device)
+                             Action<SetupPacket, byte[], Action<byte[]>> customSetupPacketHandler = null,
+                             USBSpeed speed = USBSpeed.Full) : base(18, (byte)DescriptorType.Device)
         {
             if(maximalPacketSize != PacketSize.Size8
                 && maximalPacketSize != PacketSize.Size16
@@ -43,6 +44,7 @@ namespace Antmicro.Renode.Core.USB
             configurations = new List<USBConfiguration>();
 
             CompatibleProtocolVersion = usbProtocolVersion;
+            Speed = speed;
             Class = classCode;
             SubClass = subClassCode;
             Protocol = protocol;
@@ -154,6 +156,8 @@ namespace Antmicro.Renode.Core.USB
         public byte Address { get; set; }
 
         public USBProtocol CompatibleProtocolVersion { get; }
+
+        public USBSpeed Speed { get; set; }
 
         public USBClassCode Class { get; }
 

--- a/src/Emulator/Main/Peripherals/USB/USBSpeed.cs
+++ b/src/Emulator/Main/Peripherals/USB/USBSpeed.cs
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2010-2026 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+namespace Antmicro.Renode.Core.USB
+{
+    public enum USBSpeed
+    {
+        Unknown = 0,
+        Low = 1,
+        Full = 2,
+        High = 3,
+        Wireless = 4,
+        Super = 5,
+        SuperPlus = 6,
+    }
+}

--- a/src/Emulator/Main/Tests/UnitTests/USBIPServerTests.cs
+++ b/src/Emulator/Main/Tests/UnitTests/USBIPServerTests.cs
@@ -149,6 +149,38 @@ namespace Antmicro.Renode.UnitTests
         }
 
         [Test]
+        public void ShouldReportFullSpeedByDefaultInDeviceDescriptor()
+        {
+            var dummyDevice = new DummyUSBDevice();
+            var descBytes = InvokeGenerateDeviceDescriptor(dummyDevice, 1, false).ToArray();
+            var devDescriptor = Packet.Decode<DeviceDescriptor>(descBytes);
+
+            // USBSpeed.Full is 2; USBSpeed.High is 3
+            Assert.AreEqual((int)USBSpeed.Full, devDescriptor.Speed);
+        }
+
+        [Test]
+        public void ShouldReportHighSpeedWhenRequestedViaUSBCore()
+        {
+            var dummyDevice = new DummyUSBDevice(USBSpeed.High);
+            var descBytes = InvokeGenerateDeviceDescriptor(dummyDevice, 1, false).ToArray();
+            var devDescriptor = Packet.Decode<DeviceDescriptor>(descBytes);
+
+            Assert.AreEqual((int)USBSpeed.High, devDescriptor.Speed);
+        }
+
+        [Test]
+        public void ShouldReportSpeedWhenOverriddenOnServer()
+        {
+            var dummyDevice = new DummyUSBDevice();
+            server.SetDeviceSpeed(dummyDevice, USBSpeed.High);
+            var descBytes = InvokeGenerateDeviceDescriptor(dummyDevice, 1, false).ToArray();
+            var devDescriptor = Packet.Decode<DeviceDescriptor>(descBytes);
+
+            Assert.AreEqual((int)USBSpeed.High, devDescriptor.Speed);
+        }
+
+        [Test]
         public void ShouldTimeoutOnUnresponsiveSetupPacket()
         {
             var unresponsiveDevice = new UnresponsiveUSBDevice();
@@ -184,6 +216,12 @@ namespace Antmicro.Renode.UnitTests
             return (IEnumerable<byte>)method.Invoke(server, new object[] { hdr, req, data, status });
         }
 
+        private IEnumerable<byte> InvokeGenerateDeviceDescriptor(IUSBDevice device, uint deviceNumber, bool includeInterfaces)
+        {
+            var method = typeof(USBIPServer).GetMethod("GenerateDeviceDescriptor", BindingFlags.NonPublic | BindingFlags.Instance);
+            return (IEnumerable<byte>)method.Invoke(server, new object[] { device, deviceNumber, includeInterfaces });
+        }
+
         private byte[] InvokeHandleSetupPacketSync(IUSBDevice device, SetupPacket setupPacket, int timeoutMs)
         {
             var method = typeof(USBIPServer).GetMethod("HandleSetupPacketSync", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -209,6 +247,21 @@ namespace Antmicro.Renode.UnitTests
         }
 
         private USBIPServer server;
+
+        private class DummyUSBDevice : IUSBDevice
+        {
+            public DummyUSBDevice(USBSpeed speed = USBSpeed.Full)
+            {
+                USBCore = new USBDeviceCore(this, speed: speed);
+            }
+
+            public void Reset()
+            {
+                USBCore.Reset();
+            }
+
+            public USBDeviceCore USBCore { get; }
+        }
 
         private class BlockingEndpointUSBDevice : IUSBDevice
         {

--- a/src/Emulator/Main/Tests/UnitTests/USBIPServerTests.cs
+++ b/src/Emulator/Main/Tests/UnitTests/USBIPServerTests.cs
@@ -79,6 +79,80 @@ namespace Antmicro.Renode.UnitTests
             Assert.IsTrue(completedInTime, "FeedBytes blocked on endpoint read instead of queuing asynchronously.");
         }
 
+        [Test]
+        public void ShouldReportErrorStatusAndZeroLengthOnStallReply()
+        {
+            var hdr = new URBHeader
+            {
+                Command = URBCommand.URBRequest,
+                SequenceNumber = 123,
+                DeviceId = 1,
+                Direction = URBDirection.In,
+                EndpointNumber = 0
+            };
+            var req = new URBRequest
+            {
+                TransferBufferLength = 64
+            };
+
+            var replyBytes = InvokeGenerateURBReply(hdr, req, null, status: -32).ToArray();
+            var replyHeader = Packet.Decode<URBHeader>(replyBytes);
+            var replyBody = Packet.Decode<URBReply>(replyBytes, Packet.CalculateLength<URBHeader>());
+
+            Assert.AreEqual(unchecked((uint)-32), replyHeader.FlagsOrStatus);
+            Assert.AreEqual(0u, replyBody.ActualLength);
+        }
+
+        [Test]
+        public void ShouldCalculateCorrectLengthForInTransferWithZeroOrEmptyData()
+        {
+            var hdr = new URBHeader
+            {
+                Command = URBCommand.URBRequest,
+                SequenceNumber = 124,
+                DeviceId = 1,
+                Direction = URBDirection.In,
+                EndpointNumber = 1
+            };
+            var req = new URBRequest
+            {
+                TransferBufferLength = 64
+            };
+
+            var replyBytes = InvokeGenerateURBReply(hdr, req, Array.Empty<byte>(), status: 0).ToArray();
+            var replyBody = Packet.Decode<URBReply>(replyBytes, Packet.CalculateLength<URBHeader>());
+
+            Assert.AreEqual(0u, replyBody.ActualLength);
+        }
+
+        [Test]
+        public void ShouldCalculateCorrectLengthForOutTransfer()
+        {
+            var hdr = new URBHeader
+            {
+                Command = URBCommand.URBRequest,
+                SequenceNumber = 125,
+                DeviceId = 1,
+                Direction = URBDirection.Out,
+                EndpointNumber = 1
+            };
+            var req = new URBRequest
+            {
+                TransferBufferLength = 64
+            };
+
+            var replyBytes = InvokeGenerateURBReply(hdr, req, null, status: 0).ToArray();
+            var replyBody = Packet.Decode<URBReply>(replyBytes, Packet.CalculateLength<URBHeader>());
+
+            Assert.AreEqual(64u, replyBody.ActualLength);
+        }
+
+        private IEnumerable<byte> InvokeGenerateURBReply(URBHeader hdr, URBRequest req, IEnumerable<byte> data, int status)
+        {
+            var method = typeof(USBIPServer).GetMethod("GenerateURBReply", BindingFlags.NonPublic | BindingFlags.Instance);
+            return (IEnumerable<byte>)method.Invoke(server, new object[] { hdr, req, data, status });
+        }
+
         private void FeedBytes(IEnumerable<byte> bytes)
         {
             var method = typeof(USBIPServer).GetMethod("HandleIncomingData", BindingFlags.NonPublic | BindingFlags.Instance);

--- a/src/Emulator/Main/Tests/UnitTests/USBIPServerTests.cs
+++ b/src/Emulator/Main/Tests/UnitTests/USBIPServerTests.cs
@@ -1,0 +1,118 @@
+//
+// Copyright (c) 2010-2026 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure;
+using Antmicro.Renode.Core.USB;
+using Antmicro.Renode.Extensions.Utilities.USBIP;
+using Antmicro.Renode.Utilities.Packets;
+using NUnit.Framework;
+
+namespace Antmicro.Renode.UnitTests
+{
+    [TestFixture]
+    public class USBIPServerTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            server = new USBIPServer(3240);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            server.Dispose();
+        }
+
+        [Test]
+        public void ShouldReadFromDeviceToHostEndpointAsynchronously()
+        {
+            var device = new BlockingEndpointUSBDevice();
+            device.USBCore.SelectedConfiguration = device.USBCore.Configurations.First();
+            server.Register(device, 1);
+
+            // 1. Attach device (Command.AttachDevice)
+            var attachHeader = new Header
+            {
+                Version = 0x0111,
+                Command = Command.AttachDevice,
+                Status = 0
+            };
+            var busIdBytes = new byte[32];
+            Encoding.ASCII.GetBytes("1-1").CopyTo(busIdBytes, 0);
+            var attachDesc = new AttachDeviceCommandDescriptor
+            {
+                BusId = busIdBytes
+            };
+            FeedBytes(Packet.Encode(attachHeader).Concat(Packet.Encode(attachDesc)));
+
+            // 2. Send URBRequest for endpoint 1 (Direction: DeviceToHost / IN)
+            var urbHeader = new URBHeader
+            {
+                Command = URBCommand.URBRequest,
+                SequenceNumber = 1,
+                BusId = 1,
+                DeviceId = 1,
+                Direction = URBDirection.In,
+                EndpointNumber = 1
+            };
+            var urbRequest = new URBRequest
+            {
+                TransferBufferLength = 64
+            };
+
+            // Without asynchronous read on ThreadPool, calling FeedBytes blocks indefinitely waiting on ep.Read!
+            var feedTask = Task.Run(() => FeedBytes(Packet.Encode(urbHeader).Concat(Packet.Encode(urbRequest))));
+            var completedInTime = feedTask.Wait(TimeSpan.FromMilliseconds(500));
+
+            Assert.IsTrue(completedInTime, "FeedBytes blocked on endpoint read instead of queuing asynchronously.");
+        }
+
+        private void FeedBytes(IEnumerable<byte> bytes)
+        {
+            var method = typeof(USBIPServer).GetMethod("HandleIncomingData", BindingFlags.NonPublic | BindingFlags.Instance);
+            foreach(var b in bytes)
+            {
+                method.Invoke(server, new object[] { (int)b });
+            }
+        }
+
+        private USBIPServer server;
+
+        private class BlockingEndpointUSBDevice : IUSBDevice
+        {
+            public BlockingEndpointUSBDevice()
+            {
+                USBCore = new USBDeviceCore(this)
+                    .WithConfiguration(configure: c =>
+                        c.WithInterface(new Core.USB.HID.Interface(this, 0),
+                            configure: i =>
+                                i.WithEndpoint(
+                                    Direction.DeviceToHost,
+                                    EndpointTransferType.Interrupt,
+                                    maximumPacketSize: 0x4,
+                                    interval: 0xa,
+                                    createdEndpoint: out endpoint)));
+            }
+
+            public void Reset()
+            {
+                USBCore.Reset();
+            }
+
+            public USBDeviceCore USBCore { get; }
+            private USBEndpoint endpoint;
+        }
+    }
+}

--- a/src/Emulator/Main/Tests/UnitTests/USBIPServerTests.cs
+++ b/src/Emulator/Main/Tests/UnitTests/USBIPServerTests.cs
@@ -17,6 +17,7 @@ using Antmicro.Renode.Core.USB;
 using Antmicro.Renode.Extensions.Utilities.USBIP;
 using Antmicro.Renode.Utilities.Packets;
 using NUnit.Framework;
+using USB = Antmicro.Renode.Extensions.Utilities.USB;
 
 namespace Antmicro.Renode.UnitTests
 {
@@ -147,10 +148,55 @@ namespace Antmicro.Renode.UnitTests
             Assert.AreEqual(64u, replyBody.ActualLength);
         }
 
+        [Test]
+        public void ShouldTimeoutOnUnresponsiveSetupPacket()
+        {
+            var unresponsiveDevice = new UnresponsiveUSBDevice();
+            var setupPacket = new SetupPacket
+            {
+                Recipient = PacketRecipient.Device,
+                Type = PacketType.Standard,
+                Direction = Direction.DeviceToHost,
+                Request = (byte)StandardRequest.GetDescriptor
+            };
+
+            byte[] result = null;
+            Assert.DoesNotThrow(() =>
+            {
+                result = InvokeHandleSetupPacketSync(unresponsiveDevice, setupPacket, 50);
+            });
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ShouldHandleTruncatedConfigurationDescriptorSafely()
+        {
+            var truncatedDevice = new TruncatedDescriptorUSBDevice();
+            var result = InvokeReadConfigurationDescriptor(truncatedDevice, 0, out var ifaces);
+
+            Assert.IsEmpty(ifaces);
+        }
+
         private IEnumerable<byte> InvokeGenerateURBReply(URBHeader hdr, URBRequest req, IEnumerable<byte> data, int status)
         {
             var method = typeof(USBIPServer).GetMethod("GenerateURBReply", BindingFlags.NonPublic | BindingFlags.Instance);
             return (IEnumerable<byte>)method.Invoke(server, new object[] { hdr, req, data, status });
+        }
+
+        private byte[] InvokeHandleSetupPacketSync(IUSBDevice device, SetupPacket setupPacket, int timeoutMs)
+        {
+            var method = typeof(USBIPServer).GetMethod("HandleSetupPacketSync", BindingFlags.NonPublic | BindingFlags.Instance);
+            return (byte[])method.Invoke(server, new object[] { device, setupPacket, timeoutMs });
+        }
+
+        private USB.ConfigurationDescriptor InvokeReadConfigurationDescriptor(IUSBDevice device, byte configId, out USB.InterfaceDescriptor[] ifaces)
+        {
+            var method = typeof(USBIPServer).GetMethod("ReadConfigurationDescriptor", BindingFlags.NonPublic | BindingFlags.Instance);
+            var parameters = new object[] { device, configId, null };
+            var result = (USB.ConfigurationDescriptor)method.Invoke(server, parameters);
+            ifaces = (USB.InterfaceDescriptor[])parameters[2];
+            return result;
         }
 
         private void FeedBytes(IEnumerable<byte> bytes)
@@ -187,6 +233,43 @@ namespace Antmicro.Renode.UnitTests
 
             public USBDeviceCore USBCore { get; }
             private USBEndpoint endpoint;
+        }
+
+        private class UnresponsiveUSBDevice : IUSBDevice
+        {
+            public UnresponsiveUSBDevice()
+            {
+                USBCore = new USBDeviceCore(this, customSetupPacketHandler: (packet, data, cb) =>
+                {
+                    // Never invokes cb to simulate hang/unresponsive firmware
+                });
+            }
+
+            public void Reset()
+            {
+                USBCore.Reset();
+            }
+
+            public USBDeviceCore USBCore { get; }
+        }
+
+        private class TruncatedDescriptorUSBDevice : IUSBDevice
+        {
+            public TruncatedDescriptorUSBDevice()
+            {
+                USBCore = new USBDeviceCore(this, customSetupPacketHandler: (packet, data, cb) =>
+                {
+                    // Return truncated 2 bytes
+                    cb(new byte[] { 0x02, 0x02 });
+                });
+            }
+
+            public void Reset()
+            {
+                USBCore.Reset();
+            }
+
+            public USBDeviceCore USBCore { get; }
         }
     }
 }

--- a/src/Emulator/Peripherals/Peripherals/USB/USBPendrive.cs
+++ b/src/Emulator/Peripherals/Peripherals/USB/USBPendrive.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) 2010-2025 Antmicro
 //
 // This file is licensed under the MIT License.
@@ -31,16 +31,16 @@ namespace Antmicro.Renode.Peripherals.USB
             machine.SetLocalName(pendrive, name);
         }
 
-        public static void PendriveFromFile(this USBIPServer usbController, string file, bool persistent = true, int? port = null, CompressionType compression = CompressionType.None)
+        public static void PendriveFromFile(this USBIPServer usbController, string file, bool persistent = true, int? port = null, CompressionType compression = CompressionType.None, USBSpeed? speed = null)
         {
-            var pendrive = new USBPendrive(file, persistent: persistent, compression: compression);
-            usbController.Register(pendrive, port);
+            var pendrive = new USBPendrive(file, persistent: persistent, compression: compression, speed: speed ?? USBSpeed.Full);
+            usbController.Register(pendrive, port, speed);
         }
     }
 
     public class USBPendrive : IUSBDevice, IDisposable
     {
-        public USBPendrive(string imageFile, long? size = null, bool persistent = false, uint blockSize = 512, CompressionType compression = CompressionType.None)
+        public USBPendrive(string imageFile, long? size = null, bool persistent = false, uint blockSize = 512, CompressionType compression = CompressionType.None, USBSpeed speed = USBSpeed.Full)
         {
             BlockSize = blockSize;
             dataBackend = DataStorage.CreateFromFile(imageFile, size, persistent, compression: compression);
@@ -52,7 +52,7 @@ namespace Antmicro.Renode.Peripherals.USB
                 this.Log(LogLevel.Warning, "Underlying data size extended by {0} bytes to align it to the block size ({1} bytes)", blockSize - sizeMisalignment, blockSize);
             }
 
-            USBCore = new USBDeviceCore(this)
+            USBCore = new USBDeviceCore(this, speed: speed)
                 .WithConfiguration(configure: c => c.WithInterface<Core.USB.MSC.Interface>(
                     (byte)Core.USB.MSC.Subclass.ScsiTransparentCommandSet,
                     (byte)Core.USB.MSC.Protocol.BulkOnlyTransport,


### PR DESCRIPTION
### Description

This PR introduces targeted reliability fixes, spec-compliance improvements, and dedicated unit tests for `USBIPServer`:

- **Non-blocking IN endpoint reads**: Offloads `ep.Read` to `ThreadPool` workers with synchronized socket writing (`lock(sendLock)`), preventing blocking endpoints (such as interrupt/bulk IN endpoints awaiting device data) from freezing the main TCP receive loop.
- **Direction-aware URB reply lengths**: Distinguishes OUT transfers (`req.TransferBufferLength`) from IN transfers (`data?.Count() ?? 0`) and correctly propagates status codes (e.g., `-32` for STALL/`EPIPE`), preventing host OS drivers from miscalculating payload sizes on 0-byte or stalled responses.
- **Bounded setup packet timeouts**: Adds timeout guards (1000–1500ms) to `HandleSetupPacketSync` and checks descriptor boundary lengths to prevent hangs and out-of-bounds reads during descriptor enumeration.
- **Speed reporting**: Defaults speed to `USBSpeed.Full` (matching the 64-byte max packet sizes of standard Renode USB peripheral models like `USBPendrive`, `USBKeyboard`, `USBMouse`, `ArduinoLoader`, `NRF_USBD`), with support for callers to explicitly request `USBSpeed.High` via `USBCore.Speed`, `USBIPServer.Register`, `USBIPServer.SetDeviceSpeed`, or `PendriveFromFile`.
- **Unit Test Suite**: Adds `USBIPServerTests.cs` covering STALL URB replies, 0-byte IN transfers, full speed reporting by default, caller-requested high speed reporting, timeouts, and descriptor parsing bounds.

### Commit Series

1. `[FIX] USBIPServer: Handle DeviceToHost endpoint reads asynchronously`
2. `[FIX] USBIPServer: Fix URB reply actual length calculation and status code reporting`
3. `[FIX] USBIPServer: Add timeout and length boundary checks for setup packet descriptor reads`
4. `[FIX] USBIPServer: Default to Full speed with configurable High speed support`

### Additional information & Compatibility

- **Backward Compatibility**: Verified against all existing USB models in Renode.
- **Test Suite**: Passed full Renode unit test suite (including `USBIPServerTests.cs`).
- **Integration**: Tested with Linux kernel `vhci_hcd` host driver over USB-IP.