### PR TITLE
USB: add a stall channel to the pipe interfaces, fix host-to-device status stage

### DIFF
--- a/src/Emulator/Main/Peripherals/USB/IUSBDevice.cs
+++ b/src/Emulator/Main/Peripherals/USB/IUSBDevice.cs
@@ -19,12 +19,20 @@ public interface IUSBPipeSetup : IUSBPipeRead, IUSBPipeWrite
 {
     void SetupPacketWrite(SetupPacket packet);
 
+    /// <summary>
+    /// Performs a device-to-host control transfer. <paramref name="onRead"/> is called with
+    /// <c>null</c> if the device answered with a STALL handshake (see
+    /// <see cref="IUSBPipeRead.Stalled"/>), in which case there is no status stage.
+    /// </summary>
     void SetupRead(SetupPacket packet, Action<byte[]> onRead)
     {
         SetupPacketWrite(packet);
         ReadAtLeast(packet.Count, data =>
         {
-            Write(new byte[] { });
+            if(data != null)
+            {
+                Write(new byte[] { });
+            }
             onRead(data);
         });
     }
@@ -42,6 +50,23 @@ public interface IUSBPipeSetup : IUSBPipeRead, IUSBPipeWrite
     }
 
     void SetupWriteBlocking(SetupPacket packet, byte[] data, CancellationToken token = default) => Misc.WaitForCallback(onDone => SetupWrite(packet, data, onDone), token);
+
+    /// <summary>
+    /// Performs a host-to-device control transfer, reporting whether it was accepted.
+    /// <paramref name="onDone"/> is called with <c>false</c> if the device answered with a STALL
+    /// handshake (see <see cref="IUSBPipeRead.Stalled"/>) instead of completing the status stage.
+    /// The <see cref="Action"/> overload above cannot tell the two apart, so it never completes
+    /// on a stalled transfer.
+    /// </summary>
+    void SetupWrite(SetupPacket packet, byte[] data, Action<bool> onDone)
+    {
+        SetupPacketWrite(packet);
+        if(data != null)
+        {
+            Write(data);
+        }
+        ReadPacket(res => onDone(res != null));
+    }
 
     void SetAddress(byte address, Action onDone)
     {
@@ -73,6 +98,10 @@ public interface IUSBPipeSetup : IUSBPipeRead, IUSBPipeWrite
         SetupWrite(setup, null, onDone);
     }
 
+    /// <summary>
+    /// Reads the device descriptor. <paramref name="onRead"/> is not called at all if the device
+    /// stalls the request.
+    /// </summary>
     void ReadDeviceDescriptor(Action<DeviceDescriptor> onRead)
     {
         var setupPacket = new SetupPacket
@@ -88,12 +117,23 @@ public interface IUSBPipeSetup : IUSBPipeRead, IUSBPipeWrite
 
         SetupRead(
             setupPacket,
-            res => onRead(Packet.Decode<DeviceDescriptor>(res))
+            res =>
+            {
+                if(res == null)
+                {
+                    return;
+                }
+                onRead(Packet.Decode<DeviceDescriptor>(res));
+            }
         );
     }
 
     DeviceDescriptor ReadDeviceDescriptorBlocking(CancellationToken token = default) => Misc.WaitForCallback<DeviceDescriptor>(onDone => ReadDeviceDescriptor(onDone), token);
 
+    /// <summary>
+    /// Reads the configuration descriptor. <paramref name="onRead"/> is not called at all if the
+    /// device stalls either of the two requests it takes.
+    /// </summary>
     void ReadConfigurationDescriptor(byte configuration, Action<(ConfigurationDescriptor, IEnumerable<IDescriptor>)> onRead)
     {
         var setupPacket = new SetupPacket
@@ -111,11 +151,22 @@ public interface IUSBPipeSetup : IUSBPipeRead, IUSBPipeWrite
             setupPacket,
             res =>
             {
+                if(res == null)
+                {
+                    return;
+                }
                 var config = Packet.Decode<ConfigurationDescriptor>(res);
                 setupPacket.Count = config.TotalLength;
                 SetupRead(
                     setupPacket,
-                    res => onRead((config, IDescriptor.EnumerateDescriptors(res)))
+                    res =>
+                    {
+                        if(res == null)
+                        {
+                            return;
+                        }
+                        onRead((config, IDescriptor.EnumerateDescriptors(res)));
+                    }
                 );
             }
         );
@@ -163,14 +214,32 @@ public interface IUSBPipeRead
 {
     event Action NewPacket;
 
+    /// <summary>
+    /// Raised when the device answered the transfer in progress with a STALL handshake
+    /// (USB 2.0 SS 8.4.5) instead of data or a successful status stage.
+    /// </summary>
+    /// <remarks>
+    /// Without a status signal a host that has issued a control transfer and is waiting in
+    /// <see cref="ReadAtLeast"/> for a response the device will never send waits forever. The
+    /// <c>Read*</c> helpers below observe this event and complete with a <c>null</c> buffer, so
+    /// a stalled transfer fails instead of hanging. A pipe implementation that cannot detect a
+    /// stall declares this event and simply never raises it.
+    /// </remarks>
+    event Action Stalled;
+
     // NOTE: If multiple reads are requested at once, earlier calls to `Read*` will take precedence over later onces
 
+    /// <summary>
+    /// Reads a single packet. <paramref name="cb"/> is called with <c>null</c> if the transfer
+    /// was stalled - see <see cref="Stalled"/>.
+    /// </summary>
     void ReadPacket(Action<byte[]> cb)
     {
         var calledBack = false;
         var packetLock = new object();
 
         Action collectChunk = null;
+        Action onStalled = null;
         collectChunk = () =>
         {
             lock(packetLock)
@@ -185,19 +254,40 @@ public interface IUSBPipeRead
                 }
                 calledBack = true;
                 NewPacket -= collectChunk;
+                Stalled -= onStalled;
                 cb(data);
+            }
+        };
+        onStalled = () =>
+        {
+            lock(packetLock)
+            {
+                if(calledBack)
+                {
+                    return;
+                }
+                calledBack = true;
+                NewPacket -= collectChunk;
+                Stalled -= onStalled;
+                cb(null);
             }
         };
 
         lock(this)
         {
             NewPacket += collectChunk;
+            Stalled += onStalled;
             collectChunk();
         }
     }
 
     byte[] ReadPacketBlocking(CancellationToken token = default) => Misc.WaitForCallback<byte[]>(ReadPacket, token);
 
+    /// <summary>
+    /// Reads until at least <paramref name="minLength"/> bytes have been collected.
+    /// <paramref name="cb"/> is called with <c>null</c> if the transfer was stalled before that
+    /// happened - see <see cref="Stalled"/>.
+    /// </summary>
     void ReadAtLeast(int minLength, Action<byte[]> cb)
     {
         var calledBack = false;
@@ -205,6 +295,7 @@ public interface IUSBPipeRead
         var packetLock = new object();
 
         Action collectChunk = null;
+        Action onStalled = null;
         collectChunk = () =>
         {
             lock(packetLock)
@@ -223,13 +314,29 @@ public interface IUSBPipeRead
                 }
                 calledBack = true;
                 NewPacket -= collectChunk;
+                Stalled -= onStalled;
                 cb(data.ToArray());
+            }
+        };
+        onStalled = () =>
+        {
+            lock(packetLock)
+            {
+                if(calledBack)
+                {
+                    return;
+                }
+                calledBack = true;
+                NewPacket -= collectChunk;
+                Stalled -= onStalled;
+                cb(null);
             }
         };
 
         lock(this)
         {
             NewPacket += collectChunk;
+            Stalled += onStalled;
             collectChunk();
         }
     }

--- a/src/Emulator/Main/Peripherals/USB/USBDeviceCore.cs
+++ b/src/Emulator/Main/Peripherals/USB/USBDeviceCore.cs
@@ -126,6 +126,22 @@ namespace Antmicro.Renode.Core.USB
         {
         }
 
+        // Signals that the setup transaction being handled was answered with a STALL handshake
+        // (USB 2.0 SS 9.2.7) rather than a (possibly empty) successful status stage. The pipe
+        // exposed to the host translates this into `IUSBPipeRead.Stalled`; controller peripherals
+        // that build their own pipes on top of this core can subscribe here to drive whatever
+        // wire-level stall mechanism they have.
+        public event Action<SetupPacket> RequestStalled;
+
+        // Raises `RequestStalled` on behalf of a controller peripheral. Firmware behind such a
+        // peripheral answers with a STALL long after `customSetupPacketHandler` returned (it has
+        // to write a STALL bit in its own registers first), so the stall cannot be reported as
+        // part of handling the setup packet the way the built-in request handling does.
+        public void StallRequest(SetupPacket packet)
+        {
+            RequestStalled?.Invoke(packet);
+        }
+
         public IReadOnlyCollection<USBConfiguration> Configurations => configurations;
 
         public USBConfiguration SelectedConfiguration { get; set; }
@@ -201,7 +217,11 @@ namespace Antmicro.Renode.Core.USB
                 var iface = SelectedConfiguration.Interfaces.FirstOrDefault(x => x.Identifier == packet.Index);
                 if(iface == null)
                 {
+                    // USB 2.0 SS 9.2.7: a request to a non-existing recipient must be stalled
                     device.Log(LogLevel.Warning, "Trying to access a non-existing interface #{0}", packet.Index);
+                    RequestStalled?.Invoke(packet);
+                    responseCallback(new byte[] { });
+                    return;
                 }
                 result = iface.HandleRequest(packet);
                 break;
@@ -243,7 +263,7 @@ namespace Antmicro.Renode.Core.USB
                         device.Log(LogLevel.Warning, "Wrong direction of Get Descriptor Standard Request");
                         break;
                     }
-                    return HandleGetDescriptor(packet.Value);
+                    return HandleGetDescriptor(packet);
                 case StandardRequest.SetConfiguration:
                     SelectedConfiguration = Configurations.SingleOrDefault(x => x.Identifier == packet.Value);
                     if(SelectedConfiguration == null)
@@ -252,7 +272,10 @@ namespace Antmicro.Renode.Core.USB
                     }
                     break;
                 default:
+                    // USB 2.0 SS 9.2.7: an unsupported request must be stalled, not completed as
+                    // a zero-length success
                     device.Log(LogLevel.Warning, "Unsupported standard request: 0x{0:X}", packet.Request);
+                    RequestStalled?.Invoke(packet);
                     break;
                 }
             }
@@ -260,8 +283,9 @@ namespace Antmicro.Renode.Core.USB
             return BitStream.Empty;
         }
 
-        private BitStream HandleGetDescriptor(ushort value)
+        private BitStream HandleGetDescriptor(SetupPacket packet)
         {
+            var value = packet.Value;
             var descriptorType = (DescriptorType)(value >> 8);
             var descriptorIndex = (byte)value;
 
@@ -270,9 +294,13 @@ namespace Antmicro.Renode.Core.USB
             case DescriptorType.Device:
                 return GetDescriptor(false);
             case DescriptorType.Configuration:
-                if(Configurations.Count < descriptorIndex)
+                if(descriptorIndex >= Configurations.Count)
                 {
+                    // USB 2.0 SS 9.4.3: a request for a descriptor that does not exist must be
+                    // stalled. The bound was also off by one, so index == Count used to fall
+                    // through to `ElementAt` and throw
                     device.Log(LogLevel.Warning, "Tried to access a non-existing configuration #{0}", descriptorIndex);
+                    RequestStalled?.Invoke(packet);
                     return BitStream.Empty;
                 }
                 return Configurations.ElementAt(descriptorIndex).GetDescriptor(true);
@@ -313,6 +341,17 @@ namespace Antmicro.Renode.Core.USB
             public USBPipeSetupEp0(USBDeviceCore core)
             {
                 this.core = core;
+                core.RequestStalled += _ =>
+                {
+                    stalled = true;
+                    if(!handlingSetup)
+                    {
+                        // Asynchronous stall from a controller peripheral (see `StallRequest`):
+                        // the `ReportStall` call that goes with this transfer has already run,
+                        // so report it directly instead
+                        ReportStall();
+                    }
+                };
             }
 
             public bool TryRead(out byte[] data) => readBuffer.TryDequeue(out data);
@@ -323,17 +362,29 @@ namespace Antmicro.Renode.Core.USB
                 {
                     core.device.WarningLog("Received setup packet twice in a row");
                 }
+                stalled = false;
                 if(packet.Direction == Direction.DeviceToHost)
                 {
-                    core.HandleEp0SetupPacket(packet, null, Enqueue);
+                    HandleSetupPacket(packet, null, res =>
+                    {
+                        if(stalled)
+                        {
+                            return;
+                        }
+                        Enqueue(res);
+                    });
+                    ReportStall();
                 }
                 else if(packet.Count == 0)
                 {
-                    core.HandleEp0SetupPacket(packet, null);
-                    // A request with no data stage is acknowledged by a zero-length IN packet;
-                    // without it the host side of `SetupWrite` waits forever for a status stage
-                    // that never arrives
-                    Enqueue(new byte[] { });
+                    HandleSetupPacket(packet, null);
+                    if(!ReportStall())
+                    {
+                        // A request with no data stage is acknowledged by a zero-length IN packet;
+                        // without it the host side of `SetupWrite` waits forever for a status stage
+                        // that never arrives
+                        Enqueue(new byte[] { });
+                    }
                 }
                 else
                 {
@@ -348,23 +399,52 @@ namespace Antmicro.Renode.Core.USB
                     core.device.WarningLog("Recieved a write without a write setup packet");
                     return;
                 }
-                core.HandleEp0SetupPacket(pendingPacket.Value, data);
+                var packet = pendingPacket.Value;
                 pendingPacket = null;
-                // status stage of a host-to-device transfer - see above
-                Enqueue(new byte[] { });
+                stalled = false;
+                HandleSetupPacket(packet, data);
+                if(!ReportStall())
+                {
+                    // status stage of a host-to-device transfer - see above
+                    Enqueue(new byte[] { });
+                }
             }
 
             public void SetupWrite(SetupPacket packet, byte[] data)
             {
-                core.HandleEp0SetupPacket(packet, data);
+                HandleSetupPacket(packet, data);
+            }
+
+            // As with `SetupRead` below: this core answers inline, so a STALL is raised while
+            // `HandleEp0SetupPacket` is still running - before the interface default would have
+            // armed its `ReadPacket`, which would then wait forever for a status stage that is
+            // never coming. Report the outcome to the caller directly instead.
+            public void SetupWrite(SetupPacket packet, byte[] data, Action<bool> onDone)
+            {
+                stalled = false;
+                HandleSetupPacket(packet, data);
+                onDone(!ReportStall());
             }
 
             public void SetupRead(SetupPacket packet, Action<byte[]> onRead)
             {
-                core.HandleEp0SetupPacket(packet, null, onRead);
+                stalled = false;
+                pendingRead = onRead;
+                HandleSetupPacket(packet, null, res =>
+                {
+                    if(pendingRead == null)
+                    {
+                        return;
+                    }
+                    pendingRead = null;
+                    onRead(res);
+                });
+                ReportStall();
             }
 
             public event Action NewPacket;
+
+            public event Action Stalled;
 
             private void Enqueue(byte[] data)
             {
@@ -372,7 +452,39 @@ namespace Antmicro.Renode.Core.USB
                 NewPacket?.Invoke();
             }
 
+            private void HandleSetupPacket(SetupPacket packet, byte[] data, Action<byte[]> responseCallback = null)
+            {
+                handlingSetup = true;
+                try
+                {
+                    core.HandleEp0SetupPacket(packet, data, responseCallback);
+                }
+                finally
+                {
+                    handlingSetup = false;
+                }
+            }
+
+            // Delivers a stall raised during the transfer just handled to whoever is waiting for
+            // it, and reports whether there was one.
+            private bool ReportStall()
+            {
+                if(!stalled)
+                {
+                    return false;
+                }
+                stalled = false;
+                var onRead = pendingRead;
+                pendingRead = null;
+                Stalled?.Invoke();
+                onRead?.Invoke(null);
+                return true;
+            }
+
             private SetupPacket? pendingPacket;
+            private bool stalled;
+            private bool handlingSetup;
+            private Action<byte[]> pendingRead;
 
             private readonly ConcurrentQueue<byte[]> readBuffer = new();
 

--- a/src/Emulator/Main/Peripherals/USB/USBDeviceCore.cs
+++ b/src/Emulator/Main/Peripherals/USB/USBDeviceCore.cs
@@ -325,15 +325,15 @@ namespace Antmicro.Renode.Core.USB
                 }
                 if(packet.Direction == Direction.DeviceToHost)
                 {
-                    core.HandleEp0SetupPacket(packet, null, res =>
-                    {
-                        readBuffer.Enqueue(res);
-                        NewPacket?.Invoke();
-                    });
+                    core.HandleEp0SetupPacket(packet, null, Enqueue);
                 }
                 else if(packet.Count == 0)
                 {
                     core.HandleEp0SetupPacket(packet, null);
+                    // A request with no data stage is acknowledged by a zero-length IN packet;
+                    // without it the host side of `SetupWrite` waits forever for a status stage
+                    // that never arrives
+                    Enqueue(new byte[] { });
                 }
                 else
                 {
@@ -350,6 +350,8 @@ namespace Antmicro.Renode.Core.USB
                 }
                 core.HandleEp0SetupPacket(pendingPacket.Value, data);
                 pendingPacket = null;
+                // status stage of a host-to-device transfer - see above
+                Enqueue(new byte[] { });
             }
 
             public void SetupWrite(SetupPacket packet, byte[] data)
@@ -363,6 +365,12 @@ namespace Antmicro.Renode.Core.USB
             }
 
             public event Action NewPacket;
+
+            private void Enqueue(byte[] data)
+            {
+                readBuffer.Enqueue(data);
+                NewPacket?.Invoke();
+            }
 
             private SetupPacket? pendingPacket;
 

--- a/src/Emulator/Main/Peripherals/USB/USBEndpoint.cs
+++ b/src/Emulator/Main/Peripherals/USB/USBEndpoint.cs
@@ -102,6 +102,12 @@ namespace Antmicro.Renode.Core.USB
 
         public bool TryRead(out byte[] data) => readBuffer.TryDequeue(out data);
 
+        // Answers the transfer in progress with a STALL handshake - see `IUSBPipeRead.Stalled`.
+        public void DeviceStall()
+        {
+            Stalled?.Invoke();
+        }
+
         public override string ToString()
         {
             return $"[EP: id={Identifier}, dir={Direction}, type={TransferType}, mps={MaximumPacketSize}, int={Interval}]";
@@ -120,6 +126,8 @@ namespace Antmicro.Renode.Core.USB
         public bool DeviceNonBlocking { get; set; }
 
         public event Action NewPacket;
+
+        public event Action Stalled;
 
         void IUSBPipeWrite.Write(byte[] packet)
         {

--- a/src/Emulator/Peripherals/Peripherals/SPI/MAX3421E.cs
+++ b/src/Emulator/Peripherals/Peripherals/SPI/MAX3421E.cs
@@ -497,6 +497,13 @@ namespace Antmicro.Renode.Peripherals.SPI
                 pipe.ReadPacket(
                     data =>
                 {
+                    if(data == null)
+                    {
+                        // HRSLT (hrSTALL) isn't modeled, so there is nothing to report to the
+                        // guest driver beyond dropping the transfer
+                        this.Log(LogLevel.Warning, "The device stalled the bulk IN transfer");
+                        return;
+                    }
                     this.Log(LogLevel.Noisy, "Received data from the device");
 #if DEBUG_PACKETS
                     this.Log(LogLevel.Noisy, Misc.PrettyPrintCollectionHex(data));

--- a/src/Emulator/Peripherals/Peripherals/USB/MPFS_USB.cs
+++ b/src/Emulator/Peripherals/Peripherals/USB/MPFS_USB.cs
@@ -383,6 +383,11 @@ namespace Antmicro.Renode.Peripherals.USB
                             var ep0 = peripheral.ConnectEndpointSetup(0);
                             ep0.SetupRead(packet, receivedBytes =>
                             {
+                                if(receivedBytes == null)
+                                {
+                                    this.Log(LogLevel.Warning, "The device stalled the control transfer");
+                                    return;
+                                }
                                 fifoFromDeviceToHost[0].EnqueueRange(receivedBytes);
                                 txInterruptsManager.SetInterrupt(TxInterrupt.Endpoint0);
                             });
@@ -445,6 +450,11 @@ namespace Antmicro.Renode.Peripherals.USB
                             endpoint.ReadPacket(
                                 bytes =>
                                 {
+                                    if(bytes == null)
+                                    {
+                                        this.Log(LogLevel.Warning, "The device stalled endpoint #{0}", endpointId);
+                                        return;
+                                    }
                                     fifoFromDeviceToHost[endpointId].EnqueueRange(bytes);
                                     requestInTransaction[endpointId].Value = false;
                                     localReceivedPacketReady.Value = true;

--- a/src/Emulator/Peripherals/Peripherals/USB/STM_USB/STM_USB.cs
+++ b/src/Emulator/Peripherals/Peripherals/USB/STM_USB/STM_USB.cs
@@ -611,6 +611,12 @@ public partial class STM_USB : BasicDoubleWordPeripheral, IUSBDevice, IDoubleWor
             remove => epIn.NewPacket -= value;
         }
 
+        public event Action Stalled
+        {
+            add => epIn.Stalled += value;
+            remove => epIn.Stalled -= value;
+        }
+
         private readonly byte endpointNumber;
         private readonly EndpointIn epIn;
         private readonly EndpointOut epOut;

--- a/src/Emulator/Peripherals/Peripherals/USB/STM_USB/STM_USB_EndpointIn.cs
+++ b/src/Emulator/Peripherals/Peripherals/USB/STM_USB/STM_USB_EndpointIn.cs
@@ -83,6 +83,12 @@ public partial class STM_USB
 
         public event Action NewPacket;
 
+        // The STALL handshake flag (DIEPCTL.STALL) isn't modeled here, so this is never raised;
+        // see `IUSBPipeRead.Stalled`.
+#pragma warning disable 67
+        public event Action Stalled;
+#pragma warning restore 67
+
         protected override void OnEndpointEnable()
         {
             if(transferSizeField.Value == 0)

--- a/src/Emulator/Peripherals/Peripherals/USB/USBHost.cs
+++ b/src/Emulator/Peripherals/Peripherals/USB/USBHost.cs
@@ -10,6 +10,7 @@ using System;
 using Antmicro.Renode.Core;
 using Antmicro.Renode.Core.Structure;
 using Antmicro.Renode.Core.USB;
+using Antmicro.Renode.Logging;
 using Antmicro.Renode.Time;
 using Antmicro.Renode.Utilities.Collections;
 
@@ -57,6 +58,10 @@ namespace Antmicro.Renode.Peripherals.USB
             return device != null;
         }
 
+        // A device that can't or won't service a request answers it with a STALL handshake
+        // (USB 2.0 8.5.3.4 / 9.2.7). Both steps below are issued with the stall-aware overload
+        // of `SetupWrite`, so such an answer stops the enumeration with a warning naming the
+        // step instead of leaving it silently stuck waiting for a status stage.
         protected void EnumerateDevice(IUSBDevice device)
         {
             var conn = device.ConnectUSB();
@@ -66,13 +71,61 @@ namespace Antmicro.Renode.Peripherals.USB
             ExecuteWithDelay(() =>
             {
                 var ep0 = conn.ConnectEndpointSetup(0);
-                ep0.SetAddress(addressCounter, () =>
+                SetAddress(ep0, addressCounter, addressAccepted =>
                 {
+                    if(!addressAccepted)
+                    {
+                        EnumerationFailed(device, "SET_ADDRESS");
+                        return;
+                    }
                     // USB configurations are 1-based (0 means unconfigured),
                     // so choose the first configuration, which all devices should have
-                    ep0.SetConfiguration(1, () => DeviceEnumerated(conn));
+                    SetConfiguration(ep0, 1, configurationAccepted =>
+                    {
+                        if(!configurationAccepted)
+                        {
+                            EnumerationFailed(device, "SET_CONFIGURATION");
+                            return;
+                        }
+                        DeviceEnumerated(conn);
+                    });
                 });
             });
+        }
+
+        private void EnumerationFailed(IUSBDevice device, string step)
+        {
+            this.Log(LogLevel.Warning, "USB enumeration of {0} failed: the device stalled {1}", device, step);
+        }
+
+        private static void SetAddress(IUSBPipeSetup ep0, byte address, Action<bool> callback)
+        {
+            var setupPacket = new SetupPacket
+            {
+                Recipient = PacketRecipient.Device,
+                Type = PacketType.Standard,
+                Direction = Core.USB.Direction.HostToDevice,
+                Request = (byte)StandardRequest.SetAddress,
+                Value = address,
+                Index = 0,
+                Count = 0
+            };
+            ep0.SetupWrite(setupPacket, null, callback);
+        }
+
+        private static void SetConfiguration(IUSBPipeSetup ep0, byte configuration, Action<bool> callback)
+        {
+            var setupPacket = new SetupPacket
+            {
+                Recipient = PacketRecipient.Device,
+                Type = PacketType.Standard,
+                Direction = Core.USB.Direction.HostToDevice,
+                Request = (byte)StandardRequest.SetConfiguration,
+                Value = configuration,
+                Index = 0,
+                Count = 0
+            };
+            ep0.SetupWrite(setupPacket, null, callback);
         }
 
         private bool TryInitializeConnectedDevice(IUSBDevice peripheral)


### PR DESCRIPTION
## Problem

Renode's USB pipes carry data but no status. `IUSBPipeRead` can say "here is a packet", never "the device answered this transfer with a STALL handshake" (USB 2.0 8.4.5 / 9.2.7). Two things follow from that:

- **A stalled control transfer hangs.** A host issues a SETUP and then waits in `ReadAtLeast` for a response a stalling device is never going to send. The enumeration, or the class-specific request, that was in flight stops there with nothing in the log to say why — it looks identical to a device that is merely slow.
- **A host-to-device transfer never completes at all.** `USBPipeSetupEp0` handled the request but never enqueued the zero-length IN packet that terminates it, so the `ReadPacket` that `SetupWrite` arms for the status stage never fired. `SetAddress` and `SetConfiguration` never called back, and no device backed by `USBDeviceCore` reached `USBHost.DeviceEnumerated`. That one is a plain bug and is fixed in its own commit, first.

`USBDeviceCore` also answered several requests that USB 2.0 requires to be stalled with a zero-length success instead: an unsupported standard request, a request to a non-existing interface (which additionally dereferenced a null interface), and a configuration descriptor index that does not exist — whose bound was off by one, so `index == Count` fell through to `ElementAt` and threw.

## Design

`event Action Stalled` on `IUSBPipeRead`, inherited by `IUSBPipeSetup`.

- `ReadPacket` and `ReadAtLeast` subscribe to it alongside `NewPacket` and complete with a `null` buffer if it fires first, unsubscribing from both on either outcome. A stalled transfer fails instead of hanging, and the existing `*Blocking` helpers return `null` for free.
- `SetupRead` skips the status stage on a stall and passes the `null` on; the descriptor helpers stop instead of decoding a response that isn't there.
- `SetupWrite` gains an `Action<bool>` overload — the `Action` one has no way to report a rejected `SET_ADDRESS` or class request to its caller.
- A pipe that cannot detect a stall declares the event and never raises it. `STM_USB` is in that position today (DIEPCTL.STALL isn't modeled), and says so in a comment.

Device side: `USBEndpoint.DeviceStall()` raises it for an endpoint, and `USBDeviceCore` grows a `RequestStalled` event that `USBPipeSetupEp0` turns into `Stalled` on the control pipe. The standard request handling raises it at the three sites listed above. `USBDeviceCore.StallRequest()` exposes the same channel to controller peripherals whose firmware writes a STALL bit in its own registers long after the setup packet was handled, possibly on another thread — that asynchronous case is reported directly rather than as part of handling the packet.

`USBHost.EnumerateDevice` issues SET_ADDRESS and SET_CONFIGURATION through the stall-aware overload and stops with a warning naming the step that was stalled. The step order is unchanged. `MPFS_USB` and `MAX3421E` collect packets straight into a FIFO, so they now check for the `null` and log; MAX3421E's HRSLT is a tag, so there is nothing to report to the guest driver beyond dropping the transfer.

## Verification

Built clean (`Infrastructure.csproj`, Release, `GUI_DISABLED=true`), no new warnings.

Behaviourally this comes out of the [simantic](https://github.com/simantic-dev) fork, where the same channel is exercised end to end by firmware fixtures running against a DWC_OTG device controller: an STM32F4 CDC-ACM image and an ESP32-P4 CDC image, both of which enumerate through `USBHost` and take real STALLs from the guest USB stack on requests it does not implement. Before the status-stage fix neither reached `DeviceEnumerated`; before the stall channel, a stalled class request wedged the console instead of failing.

The stall channel and the status-stage fix are separate commits, and the `USBHost` change is a third, so they can be taken independently.
